### PR TITLE
Add `helm_remote` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`conftest`](/conftest): Use [Conftest](https://www.conftest.dev/) to test your configuration files.
 - [`docker_build_sub`](/docker_build_sub): Specify extra Dockerfile directives in your Tiltfile beyond [`docker_build`](https://docs.tilt.dev/api.html#api.docker_build).
 - [`hello_world`](/hello_world): Print "Hello world!". Used in [Extensions](https://docs.tilt.dev/extensions.html).
+- [`helm_remote`](/helm_remote): Install a remote Helm chart (in a way that gets properly uninstalled when running `tilt down`)
 - [`jest_test_runner`](/jest_test_runner): Jest JavaScript test runner. Example from [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).
 - [`min_tilt_version`](/min_tilt_version): Require a minimum Tilt version to run this Tiltfile.
 - [`namespace`](/namespace): Functions for interacting with namespaces.

--- a/helm_remote/README.md
+++ b/helm_remote/README.md
@@ -1,0 +1,42 @@
+# Helm Remote
+
+Author: [Bob Jackman](https://github.com/kogi)
+
+Install a remotely hosted Helm chart in a way that it will be properly uninstalled when running `tilt down`
+
+## Usage
+
+Because tilt doesn't have a way to dynamically ignore files, you'll need to add `.helm` to your project's `.tiltignore`
+file in order to prevent recursive re-processing of the main Tiltfile when the helm cache changes/updates.
+
+#### Install a Remote Chart
+
+```py
+load('ext://helm_remote', 'helm_remote')
+helm_remote('myChartName')
+```
+
+##### Additional Parameters
+
+```
+helm_remote(chart_name, repo_url='', repo_name='', namespace='', version='', username='', password='', values=[], set=[])
+```
+
+* `chart_name` ( str ) – the name of the chart to install  
+* `repo_name` ( str ) – the name of the repo within which to find the chart (assuming the repo is already added locally)
+<br> if omitted, defaults to the same value as `chart_name`
+* `repo_url` ( str ) – the URL of the repo within which to find the chart (equivalent to `helm repo add <repo_name> <repo_url>`)
+* `namespace` ( str ) – the namespace to deploy the chart to (equivalent to helm's `--namespace <namespace> --create-namespace` flags)
+* `version` ( str ) – the version of the chart to install. If omitted, defaults to latest version (equivalent to helm's `--version` flag)
+* `username` ( str ) – repository authentication username, if needed (equivalent to helm's `--username` flag)
+* `password` ( str ) – repository authentication password, if needed (equivalent to helm's `--password` flag)
+* `values` ( Union [ str , List [ str ]]) – Specify one or more values files (in addition to the values.yaml file in the chart). Equivalent to the helm's `--values` or `-f` flags
+* `set` ( Union [ str , List [ str ]]) – Directly specify one or more values (equivalent to helm's `--set` flag)
+
+#### Change the Cache Location
+
+By default `helm_remote` will store retrieved helm charts in the `.helm` directory at your project's root.
+This location can be customized by calling `helm_remote_set_cache_dir(newDirectory)`.
+Whether customizing this value or just using the default location, be sure this directory is added to your project's
+`.tiltignore` file in order to prevent recursive re-processing of the main Tiltfile when the helm cache changes/updates.
+See github [issue #3404](https://github.com/tilt-dev/tilt/issues/3404)

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -1,0 +1,47 @@
+# TODO: =====================================
+#   if it ever becomes possible for loaded files to also load their own extensions
+#   this method can be replaced by `load('ext://namespace', 'namespace_create')
+def namespace_create(name):
+    """Returns YAML for a namespace
+    Args:    name: The namespace name. Currently not validated.
+    """
+    k8s_yaml(blob("""apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+""" % name))
+# TODO: end TODO
+#   =====================================
+
+
+def helm_remote(chart, repo_url='', repo_name='', namespace='', values=[], set=[]):
+    if repo_name == '':
+        repo_name = chart
+
+    if namespace == '':
+        namespace = 'default'
+
+    if repo_url != '':
+        local('helm repo add %s %s' % (repo_name, repo_url))  # updates if already added
+
+    if namespace != '':
+        # avoid a namespace not found error
+        namespace_create(namespace)  # do this early so it manages to register before we attempt to install into it
+
+    local('rm -rf helm_deps/%s' % repo_name)
+    local('helm pull %s/%s --untar --destination helm_deps/%s' % (repo_name, chart, repo_name))
+    install_crds('%s-crds' % chart, './helm_deps/%s/%s/crds' % (repo_name, chart))
+
+    # TODO: since neither `k8s_yaml()` nor `helm()` accept resource_deps, sometimes the crds haven't yet finished installing before the below tries to run
+    if namespace != '':
+        k8s_yaml(helm('helm_deps/%s/%s' % (repo_name, chart), namespace=namespace, values=values, set=set))
+    else:
+        k8s_yaml(helm('helm_deps/%s/%s' % (repo_name, chart), values=values, set=set))
+
+
+def install_crds(name, directory):
+    local_resource(name+'-install', cmd='kubectl apply -f %s' % directory, deps=listdir(directory), ignore=listdir(directory))  # we can wait/depend on this, but it won't cause a proper uninstall
+    k8s_yaml(listdir(directory))  # this will cause a proper uninstall, but we can't wait/depend on it
+
+    # TODO: Figure out how to avoid another named resource showing up in the tilt HUD for this waiter
+    return local_resource(name+'-ready', resource_deps=[name+'-install'], cmd='kubectl wait --for=condition=Established crd --all')  # now we can wait for those crds to finish establishing

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -36,7 +36,7 @@ def helm_remote(chart, repo_url='', repo_name='', values=[], set=[], namespace='
         local('helm repo add %s %s' % (repo_name, repo_url))  # updates if already added
 
     # ======== Create Namespace
-    if namespace != '':
+    if namespace != '' and namespace != 'default':
         # avoid a namespace not found error
         namespace_create(namespace)  # do this early so it manages to register before we attempt to install into it
 
@@ -62,20 +62,27 @@ def helm_remote(chart, repo_url='', repo_name='', values=[], set=[], namespace='
     # ======== Perform Installation
     local('rm -rf %s' % pull_target)
     local(pull_command)
-    install_crds(chart, '%s/crds' % chart_target)
+    install_crds(chart, chart_target)
 
     # TODO: since neither `k8s_yaml()` nor `helm()` accept resource_deps, sometimes the crds haven't yet finished installing before the below tries to run
     if namespace != '':
-        k8s_yaml(helm(chart_target, namespace=namespace, values=values, set=set))
+        k8s_yaml(helm(chart_target, name=chart, namespace=namespace, values=values, set=set))
     else:
-        k8s_yaml(helm(chart_target, values=values, set=set))
+        k8s_yaml(helm(chart_target, name=chart, values=values, set=set))
 
 
 def install_crds(name, directory):
     name += '-crds'
 
-    local_resource(name+'-install', cmd='kubectl apply -f %s' % directory, deps=listdir(directory))  # we can wait/depend on this, but it won't cause a proper uninstall
-    k8s_yaml(listdir(directory))  # this will cause a proper uninstall, but we can't wait/depend on it
+    files = str(local(r"grep --include '*.yaml' --include '*.yml' -rEil '\bkind\s*:\s+CustomResourceDefinition\s*$' %s | xargs grep -L '^{{-' | head -c -1" % directory))
+    if (files == '') or (files == '(standard input)'):
+        files = []
+    else:
+        files = files.split("\n")
 
-    # TODO: Figure out how to avoid another named resource showing up in the tilt HUD for this waiter
-    return local_resource(name+'-ready', resource_deps=[name+'-install'], cmd='kubectl wait --for=condition=Established crd --all')  # now we can wait for those crds to finish establishing
+    if len(files) != 0:
+        local_resource(name+'-install', cmd='kubectl apply -f %s' % " -f ".join(files), deps=files)  # we can wait/depend on this, but it won't cause a proper uninstall
+        k8s_yaml(files)  # this will cause a proper uninstall, but we can't wait/depend on it
+
+        # TODO: Figure out how to avoid another named resource showing up in the tilt HUD for this waiter
+        local_resource(name+'-ready', resource_deps=[name+'-install'], cmd='kubectl wait --for=condition=Established crd --all')  # now we can wait for those crds to finish establishing

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -1,3 +1,15 @@
+
+
+# this is the root directory into which remote helm charts will be pulled/cloned/untar'd
+# use `helm_remote_set_cache_dir(newDir)` to change
+# if customizing this location, you will also need to add the new location to your .tiltignore file to prevent infinite loops processing the main tiltfile
+helm_remote_cache_dir = './.helm'
+
+
+def helm_remote_set_cache_dir(directory):
+    helm_remote_cache_dir = directory
+
+
 # TODO: =====================================
 #   if it ever becomes possible for loaded files to also load their own extensions
 #   this method can be replaced by `load('ext://namespace', 'namespace_create')
@@ -14,33 +26,55 @@ metadata:
 #   =====================================
 
 
-def helm_remote(chart, repo_url='', repo_name='', namespace='', values=[], set=[]):
+def helm_remote(chart, repo_url='', repo_name='', values=[], set=[], namespace='', version='', username='', password=''):
+    # ======== Condition Incoming Arguments
     if repo_name == '':
         repo_name = chart
-
     if namespace == '':
         namespace = 'default'
-
     if repo_url != '':
         local('helm repo add %s %s' % (repo_name, repo_url))  # updates if already added
 
+    # ======== Create Namespace
     if namespace != '':
         # avoid a namespace not found error
         namespace_create(namespace)  # do this early so it manages to register before we attempt to install into it
 
-    local('rm -rf helm_deps/%s' % repo_name)
-    local('helm pull %s/%s --untar --destination helm_deps/%s' % (repo_name, chart, repo_name))
-    install_crds('%s-crds' % chart, './helm_deps/%s/%s/crds' % (repo_name, chart))
+    # ======== Initialize
+    # -------- targets
+    pull_target = '%s/%s' % (helm_remote_cache_dir, repo_name)
+    if version != '':
+        pull_target += '/%s' % version
+    else:
+        pull_target += '/latest'
+
+    chart_target = '%s/%s' % (pull_target, chart)
+
+    # -------- commands
+    pull_command = 'helm pull %s/%s --untar --destination %s' % (repo_name, chart, pull_target)
+    if version != '':
+        pull_command += ' --version %s' % version
+    if username != '':
+        pull_command += ' --username %s' % username
+    if password != '':
+        pull_command += ' --password %s' % password
+
+    # ======== Perform Installation
+    local('rm -rf %s' % pull_target)
+    local(pull_command)
+    install_crds(chart, '%s/crds' % chart_target)
 
     # TODO: since neither `k8s_yaml()` nor `helm()` accept resource_deps, sometimes the crds haven't yet finished installing before the below tries to run
     if namespace != '':
-        k8s_yaml(helm('helm_deps/%s/%s' % (repo_name, chart), namespace=namespace, values=values, set=set))
+        k8s_yaml(helm(chart_target, namespace=namespace, values=values, set=set))
     else:
-        k8s_yaml(helm('helm_deps/%s/%s' % (repo_name, chart), values=values, set=set))
+        k8s_yaml(helm(chart_target, values=values, set=set))
 
 
 def install_crds(name, directory):
-    local_resource(name+'-install', cmd='kubectl apply -f %s' % directory, deps=listdir(directory), ignore=listdir(directory))  # we can wait/depend on this, but it won't cause a proper uninstall
+    name += '-crds'
+
+    local_resource(name+'-install', cmd='kubectl apply -f %s' % directory, deps=listdir(directory))  # we can wait/depend on this, but it won't cause a proper uninstall
     k8s_yaml(listdir(directory))  # this will cause a proper uninstall, but we can't wait/depend on it
 
     # TODO: Figure out how to avoid another named resource showing up in the tilt HUD for this waiter


### PR DESCRIPTION
@victorwuky
The currently recommended way of installing remote helm files is:
```python
local("helm upgrade --install <chart> <repo>")
```

But this has a few shortcomings when running `tilt down`:
1. the helm chart is not uninstalled
1. any namespace created with helm's `--create-namespace` flag is not uninstalled (even when using `tilt down --delete-namespaces`

Another option is:
```python
local("helm pull <repo>/<chart> --untar --destination helm_deps/<chart>")
k8s_yaml(helm("helm_deps/<chart>", namespace=myNamespace))
```
This has the advantage of solving bullet #1 above, but still has other shortcomings
1. namespace must already exist in order to install there (`helm()` has no support for `--create-namespace`)
1. even if namespace already exists, it still may not be cleaned up when running `tilt down --delete-namespaces`
1. if the chart defines any CRDs, they won't be installed as part of your call to `helm()`


This extension solves all of the above. (see comments in code for a few technical caveats)