### PR TITLE
Fix compatibility issues with `head` provided by MacOS X.

### DIFF
--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -74,7 +74,7 @@ def helm_remote(chart, repo_url='', repo_name='', values=[], set=[], namespace='
 def install_crds(name, directory):
     name += '-crds'
 
-    files = str(local(r"grep --include '*.yaml' --include '*.yml' -rEil '\bkind\s*:\s+CustomResourceDefinition\s*$' %s | xargs grep -L '^{{-' | head -c -1" % directory))
+    files = str(local(r"grep --include '*.yaml' --include '*.yml' -rEil '\bkind\s*:\s+CustomResourceDefinition\s*$' %s | xargs grep -L '^{{-' | tail -r | tail -c +1 | tail -r" % directory))
     if (files == '') or (files == '(standard input)'):
         files = []
     else:


### PR DESCRIPTION
## Problem

The `helm_remote` extension fails when trying to run the `install_crds(name, directory)` function. Though [GNU head](https://www.man7.org/linux/man-pages/man1/head.1.html) supports passing negative numbers to the bytes option, the [BSD head](https://www.freebsd.org/cgi/man.cgi?query=head) shipped with MacOS X does not.

Error Logs:
```
local: grep --include '*.yaml' --include '*.yml' -rEil '\bkind\s*:\s+CustomResourceDefinition\s*$' ./.helm/bitnami/7.14.5/mongodb | xargs grep -L '^{{-' | head -c -1                                                                    
 → head: illegal byte count -- -1                                                                                                                                                                                                        
Successfully loaded Tiltfile (3.551848388s)                                                                                                                                                                                              
Traceback (most recent call last):                                                                                                                                                                                                       
  /Users/me/projects/project/Tiltfile:126:12: in <toplevel>                                                                                                                                                                           
  /Users/me/projects/project/tilt_modules/helm_remote/Tiltfile:65:17: in helm_remote                                                                                                                                                  
  /Users/me/projects/project/tilt_modules/helm_remote/Tiltfile:77:22: in install_crds                                                                                                                                                 
  <builtin>: in local                                                                                                                                                                                                                    
Error: command ["sh" "-c" "grep --include '*.yaml' --include '*.yml' -rEil '\\bkind\\s*:\\s+CustomResourceDefinition\\s*$' ./.helm/bitnami/7.14.5/mongodb | xargs grep -L '^{{-' | head -c -1"] failed.                                  
error: exit status 1
```

The isolated problem:
```sh
❯ echo "test" | head -c -1
head: illegal byte count -- -1

```

## Desired Outcome
The use of the `helm_remote` extension should work on MacOS X with no failures.

## Solution
Though more verbose, use the `tail` command to achieve the desired behavior.

Credits to: https://unix.stackexchange.com/questions/169079/negative-arguments-to-head-tail/169080#169080