### PR TITLE
local_output extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Tilt Extensions
+
 This is the official Tilt Extensions Repository. Read more in [docs](https://docs.tilt.dev/extensions.html).
 
 All extensions have been vetted and approved by the Tilt team.
@@ -15,8 +16,10 @@ All extensions have been vetted and approved by the Tilt team.
 - [`print_tiltfile_dir`](/print_tiltfile_dir): Print all files in the Tiltfile directory. If recursive is set to True, also prints files in all recursive subdirectories.
 - [`procfile`](/procfile): Create Tilt resources from a foreman Procfile.
 - [`restart_process`](/restart_process): Wrap a `docker_build` to restart the given entrypoint after a Live Update (replaces `restart_container()`)
+- [`local_output`](/local_output): Run a `local` command and get the output as string
 
 ## Contribute an Extension
+
 See [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).
 
 We want everyone to feel at home in this repo and its environs; please see our [Code of Conduct](CODE_OF_CONDUCT.md) for some rules that govern everyone's participation.

--- a/local_output/README.md
+++ b/local_output/README.md
@@ -1,0 +1,27 @@
+# local_output
+
+Author: [Çağatay Yücelen](https://github.com/cyucelen)
+
+Get the output of a shell command as string to use it in Tiltfile.
+
+`local_output` runs given command and strips trailing `\n`.
+
+## Usage
+
+Pass a command to execute with local.
+
+### Example:
+
+```python
+desired_memory_capacity = "4096"
+current_memory_capacity = local_output('minikube config get memory') # e.g. "2048"
+
+if int(current_memory_capacity) < int(desired_memory_capacity):
+    local('minikube config set memory {}'.format(desired_memory_capacity))
+    local('minikube delete')
+    local('minikube start')
+```
+
+The `pack` function can takes:
+
+- `command`: shell command to execute with `local` function

--- a/local_output/Tiltfile
+++ b/local_output/Tiltfile
@@ -1,0 +1,2 @@
+def local_output(cmd):
+  return str(local(cmd)).rstrip('\n')

--- a/local_output/Tiltfile
+++ b/local_output/Tiltfile
@@ -1,2 +1,2 @@
-def local_output(cmd):
-  return str(local(cmd)).rstrip('\n')
+def local_output(command):
+  return str(local(command)).rstrip('\n')


### PR DESCRIPTION
In the tilt.build [issue](https://github.com/tilt-dev/tilt.build/issues/179#issuecomment-639739992), @jazzdan mentioned that tilt extensions may have a functionality to get the output of a `local` command.

 I also use this frequently to put all of my scripting in my Tiltfile.