### PR TITLE
disable parallelism until https://github.com/tilt-dev/tilt/issues/3421 is fixed

### DIFF
--- a/namespace/test/Tiltfile
+++ b/namespace/test/Tiltfile
@@ -1,5 +1,9 @@
 load('../Tiltfile', 'namespace_create', 'namespace_inject')
 
+# Disable parallelism until this issue is fixed:
+# https://github.com/tilt-dev/tilt/issues/3421
+update_settings(max_parallel_updates=1)
+
 namespace_create('namespace-test')
 k8s_yaml(namespace_inject('deployment.yaml', 'namespace-test'))
 k8s_yaml('job.yaml')


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/parallel:

3df1829e28cb1748eebd870e4ad5ed9c52c90264 (2020-06-12 12:39:30 -0400)
disable parallelism until https://github.com/tilt-dev/tilt/issues/3421 is fixed

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics