### PR TITLE
fix git checkout when specifying a branch name

### DIFF
--- a/git_resource/Tiltfile
+++ b/git_resource/Tiltfile
@@ -23,7 +23,7 @@ def git_checkout(repository_url, checkout_dir=None, unsafe_mode=False):
     if checkout_dir == '' or checkout_dir == None:
         checkout_dir = _get_default_checkout_target(repository_url)
 
-    _, _, branch = _parse_repository_url(repository_url)
+    repository_url, _, branch = _parse_repository_url(repository_url)  # split the branch name away from the repo url
 
     if not os.path.exists(checkout_dir):  # needs clone
         local('git clone %s -b %s %s' % (repository_url, branch, checkout_dir), quiet=True)


### PR DESCRIPTION
Not sure how it ever worked before...

Before this change, if specifying a branch/tag name in your repo url as such: `git@github.com/owner/repo.git#branchName`, the command generated was akin to `git clone git@github.com/owner/repo.git#branchName -b branchName ./path/to/checkout`

Where the existence of that hash-tagged branch name was confusing to git (naturally so)

After this change, the same input results in a generated command of `git clone git@github.com/owner/repo.git -b branchName ./path/to/checkout`