### PR TITLE
determine the tilt root location before establishing file caches

### DIFF
--- a/git_resource/Tiltfile
+++ b/git_resource/Tiltfile
@@ -9,7 +9,8 @@ while not os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')) and os.p
     path_prefix = '../' + path_prefix
 
 if os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')):
-    git_resource_checkout_dir = os.path.abspath(path_prefix + git_resource_checkout_dir)
+    abs_path = os.path.abspath(path_prefix + git_resource_checkout_dir)
+    git_resource_checkout_dir = "/".join(abs_path.split('\\'))
 
 
 def git_resource_set_checkout_dir(directory):

--- a/git_resource/Tiltfile
+++ b/git_resource/Tiltfile
@@ -3,6 +3,14 @@
 # if customizing this location, you will also need to add the new location to your .tiltignore file to prevent infinite loops processing the main tiltfile (See github [issue #3404](https://github.com/tilt-dev/tilt/issues/3404))
 git_resource_checkout_dir = './.git-sources'
 
+# Find top-level Tilt path
+path_prefix = './'
+while not os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')) and os.path.abspath(path_prefix) != '/':
+    path_prefix = '../' + path_prefix
+
+if os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')):
+    git_resource_checkout_dir = os.path.abspath(path_prefix + git_resource_checkout_dir)
+
 
 def git_resource_set_checkout_dir(directory):
     git_resource_checkout_dir = directory

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -11,7 +11,7 @@ while not os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')) and os.p
     path_prefix = '../' + path_prefix
 
 if os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')):
-    helm_remote_cache_dir = path_prefix + helm_remote_cache_dir
+    helm_remote_cache_dir = os.abspath(path_prefix + helm_remote_cache_dir)
 
 
 def helm_remote_set_cache_dir(directory):

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -5,6 +5,14 @@
 # if customizing this location, you will also need to add the new location to your .tiltignore file to prevent infinite loops processing the main tiltfile (See github [issue #3404](https://github.com/tilt-dev/tilt/issues/3404))
 helm_remote_cache_dir = './.helm'
 
+# Find top-level Tilt path
+path_prefix = './'
+while not os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')) and os.path.abspath(path_prefix) != '/':
+    path_prefix = '../' + path_prefix
+
+if os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')):
+    helm_remote_cache_dir = path_prefix + helm_remote_cache_dir
+
 
 def helm_remote_set_cache_dir(directory):
     helm_remote_cache_dir = directory

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -11,7 +11,8 @@ while not os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')) and os.p
     path_prefix = '../' + path_prefix
 
 if os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')):
-    helm_remote_cache_dir = os.abspath(path_prefix + helm_remote_cache_dir)
+    abs_path = os.path.abspath(path_prefix + helm_remote_cache_dir)
+    helm_remote_cache_dir = "/".join(abs_path.split('\\'))
 
 
 def helm_remote_set_cache_dir(directory):


### PR DESCRIPTION
Now that #3452 has been merged, it's possible for tiltfiles to be nested, and this breaks (in a way) both the `helm_remote` and `git_resource` extensions. With nested tiltfiles, it's now possible that these extensions create their private file caches in the nested location from which they're running, rather than in the tilt root directory. This PR fixes that.