### PR TITLE
Fix how the helm_remote and git_resource extensions handle cache directories.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,5 +7,6 @@ jobs:
     steps:
       - setup_remote_docker
       - checkout
+      - run: apt update && apt install -y git
       - run: curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
       - run: with-kind-cluster.sh ./test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-helm_remote/test/.helm
+*/test/.helm
+*/test/.git-sources

--- a/git_resource/README.md
+++ b/git_resource/README.md
@@ -199,7 +199,7 @@ git_resource('myMicroservice', 'git@example.com/myRepo.git', dockerfile='Dockerf
 ### Change the Cache Location
 
 By default, when calling `deploy_from_repository()`, or using `git_resource()` with a repository url, the repo will be cloned into the `.git-sources` directory at your workspace's root.
-This location can be customized by calling `git_resource_set_checkout_dir(newDirectory)`.
+This location can be customized by calling `os.putenv('TILT_GIT_RESOURCE_CHECKOUT_DIR', new_directory)` before loading the module.
 Whether customizing this value or just using the default location, be sure this directory is added to your project's
 `.tiltignore` file in order to prevent recursive re-processing of the main Tiltfile when the helm cache changes/updates.
 See github [issue #3404](https://github.com/tilt-dev/tilt/issues/3404)

--- a/git_resource/Tiltfile
+++ b/git_resource/Tiltfile
@@ -1,21 +1,25 @@
+
+def _find_root_tiltfile_dir():
+    # Find top-level Tilt path
+    current = os.path.abspath('./')
+    while current != '/':
+        if os.path.exists(os.path.join(current, 'tilt_modules')):
+            return current
+
+        current = os.path.dirname(current)
+
+    fail('Could not find root Tiltfile')
+
+def _find_checkout_dir():
+    from_env = os.getenv('TILT_GIT_RESOURCE_CHECKOUT_DIR', '')
+    if from_env != '':
+        return from_env
+    return os.path.join(_find_root_tiltfile_dir(), '.git-sources')
+
 # this is the root directory into which remote git repositories will be cloned
-# use `git_resource_set_checkout_dir(newDir)` to change
+# use `os.putenv('TILT_GIT_RESOURCE_CHECKOUT_DIR', new_dir)` to change
 # if customizing this location, you will also need to add the new location to your .tiltignore file to prevent infinite loops processing the main tiltfile (See github [issue #3404](https://github.com/tilt-dev/tilt/issues/3404))
-git_resource_checkout_dir = './.git-sources'
-
-# Find top-level Tilt path
-path_prefix = './'
-while not os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')) and os.path.abspath(path_prefix) != '/':
-    path_prefix = '../' + path_prefix
-
-if os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')):
-    abs_path = os.path.abspath(path_prefix + git_resource_checkout_dir)
-    git_resource_checkout_dir = "/".join(abs_path.split('\\'))
-
-
-def git_resource_set_checkout_dir(directory):
-    git_resource_checkout_dir = directory
-
+git_resource_checkout_dir = _find_checkout_dir()
 
 def git_resource(resource_name, path_or_repo, dockerfile='Dockerfile', namespace='default', resource_deps=[], port_forwards=[], build_callback=None, deployment_callback=None):
     is_http = path_or_repo[:4].lower() == 'http'

--- a/git_resource/test/.tiltignore
+++ b/git_resource/test/.tiltignore
@@ -1,0 +1,1 @@
+.git-sources

--- a/git_resource/test/Tiltfile
+++ b/git_resource/test/Tiltfile
@@ -1,0 +1,9 @@
+os.putenv('TILT_GIT_RESOURCE_CHECKOUT_DIR', os.path.abspath('./.git-sources'))
+load('../Tiltfile', 'git_checkout', 'deploy_from_dir')
+
+repo_dir = git_checkout('https://github.com/tilt-dev/tilt-example-html')
+example_dir = os.path.join(repo_dir, '0-base')
+deploy_from_dir('example-html', example_dir)
+
+if not os.path.exists('./.git-sources/tilt-example-html'):
+  fail('tilt-example-html failed to load in the right directory')

--- a/git_resource/test/test.sh
+++ b/git_resource/test/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+set -ex
+tilt ci
+tilt down --delete-namespaces

--- a/helm_remote/README.md
+++ b/helm_remote/README.md
@@ -36,7 +36,7 @@ helm_remote(chart_name, repo_url='', repo_name='', namespace='', version='', use
 #### Change the Cache Location
 
 By default `helm_remote` will store retrieved helm charts in the `.helm` directory at your workspace's root.
-This location can be customized by calling `helm_remote_set_cache_dir(newDirectory)`.
+This location can be customized by calling `os.putenv('TILT_HELM_REMOTE_CACHE_DIR', new_directory)` before loading the module.
 Whether customizing this value or just using the default location, be sure this directory is added to your project's
 `.tiltignore` file in order to prevent recursive re-processing of the main Tiltfile when the helm cache changes/updates.
 See github [issue #3404](https://github.com/tilt-dev/tilt/issues/3404)

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -1,23 +1,25 @@
 
+def _find_root_tiltfile_dir():
+    # Find top-level Tilt path
+    current = os.path.abspath('./')
+    while current != '/':
+        if os.path.exists(os.path.join(current, 'tilt_modules')):
+            return current
+
+        current = os.path.dirname(current)
+
+    fail('Could not find root Tiltfile')
+
+def _find_cache_dir():
+    from_env = os.getenv('TILT_HELM_REMOTE_CACHE_DIR', '')
+    if from_env != '':
+        return from_env
+    return os.path.join(_find_root_tiltfile_dir(), '.helm')
 
 # this is the root directory into which remote helm charts will be pulled/cloned/untar'd
-# use `helm_remote_set_cache_dir(newDir)` to change
+# use `os.putenv('TILT_HELM_REMOTE_CACHE_DIR', new_dir)` to change
 # if customizing this location, you will also need to add the new location to your .tiltignore file to prevent infinite loops processing the main tiltfile (See github [issue #3404](https://github.com/tilt-dev/tilt/issues/3404))
-helm_remote_cache_dir = './.helm'
-
-# Find top-level Tilt path
-path_prefix = './'
-while not os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')) and os.path.abspath(path_prefix) != '/':
-    path_prefix = '../' + path_prefix
-
-if os.path.exists(os.path.abspath(path_prefix + 'tilt_modules')):
-    abs_path = os.path.abspath(path_prefix + helm_remote_cache_dir)
-    helm_remote_cache_dir = "/".join(abs_path.split('\\'))
-
-
-def helm_remote_set_cache_dir(directory):
-    helm_remote_cache_dir = directory
-
+helm_remote_cache_dir = _find_cache_dir()
 
 # TODO: =====================================
 #   if it ever becomes possible for loaded files to also load their own extensions
@@ -83,7 +85,7 @@ def helm_remote(chart, repo_url='', repo_name='', values=[], set=[], namespace='
 def install_crds(name, directory):
     name += '-crds'
 
-    files = str(local(r"grep --include '*.yaml' --include '*.yml' -rEil '\bkind\s*:\s+CustomResourceDefinition\s*$' %s | xargs -r grep -L '^{{-'" % directory)).strip()
+    files = str(local(r"grep --include '*.yaml' --include '*.yml' -rEil '\bkind\s*:\s+CustomResourceDefinition\s*$' %s | xargs grep -L '^{{-'" % directory)).strip()
     if (files == '') or (files == '(standard input)'):
         files = []
     else:

--- a/helm_remote/test/Tiltfile
+++ b/helm_remote/test/Tiltfile
@@ -1,7 +1,10 @@
+os.putenv('TILT_HELM_REMOTE_CACHE_DIR', os.path.abspath('./.helm'))
 load('../Tiltfile', 'helm_remote')
 
 # Note that .helm is in the .tiltignore!
 helm_remote('memcached', repo_url='https://charts.bitnami.com/bitnami')
+if not os.path.exists('./.helm/memcached'):
+  fail('memcached failed to load in the right directory')
 
 docker_build('helm-remote-test-verify', '.')
 k8s_yaml('job.yaml')

--- a/test.sh
+++ b/test.sh
@@ -3,5 +3,6 @@
 cd $(dirname $0)
 
 set -ex
+git_resource/test/test.sh
 namespace/test/test.sh
 helm_remote/test/test.sh


### PR DESCRIPTION
Hello @kogi, @jazzdan,

Please review the following commits I made in branch nicks/macos:

d2dbdb9cbcb4f4c0384efab4cf3d80adb62591fc (2020-06-25 11:21:16 -0400)
Fix how the helm_remote and git_resource extensions handle cache directories.
Starlark freezes the module after loading, and won't let you set
globals in the module.

also adds tests for git_resource

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics