### PR TITLE
support changing branches to one that may not exist in the local repo

### DIFF
--- a/git_resource/Tiltfile
+++ b/git_resource/Tiltfile
@@ -47,7 +47,7 @@ def git_checkout(repository_url, checkout_dir=None, unsafe_mode=False):
                 has_local_changes = int(str(local('cd %s && git status -sbuno | wc -l' % checkout_dir, quiet=True)).strip()) > 1  # result greater than 1 indicates local modifications are present
 
             if unsafe_mode or not has_local_changes:
-                local('cd %s && git checkout -f %s && git pull -f origin %s' % (checkout_dir, branch, branch), quiet=True)
+                local('cd %s && git fetch -a origin && git checkout -f %s' % (checkout_dir, branch), quiet=True)
             else:
                 fail('git_checkout() failed: local modifications present and safe_mode is enabled')
 


### PR DESCRIPTION
if:
- a git resource has already been cloned/checkedout locally (pointing to "branch A")
- and a new branch (branch B) is pushed to origin
- the tiltfile is updated to use that branch

then:
- we get an error saying the new branch (branch B) was not found

----

This PR fixes that by fetching all from the remote server before attempting a checkout