### PR TITLE
fix: add auth flags for add repo command

### DIFF
--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -44,7 +44,17 @@ def helm_remote(chart, repo_url='', repo_name='', values=[], set=[], namespace='
     if namespace == '':
         namespace = 'default'
     if repo_url != '':
-        local('helm repo add %s %s' % (repo_name, repo_url))  # updates if already added
+        repo_add_command = 'helm repo add %s %s' % (repo_name, repo_url)
+
+        # Add authentification for adding the repository if credentials are provided
+        if version != '':
+            repo_add_command += ' --version %s' % version
+        if username != '':
+            repo_add_command += ' --username %s' % username
+        if password != '':
+            repo_add_command += ' --password %s' % password
+
+        local(repo_add_command)  # updates if already added
 
     # ======== Create Namespace
     if namespace != '' and namespace != 'default':


### PR DESCRIPTION
Hello,

I am trying to migrate my current architecture with local helm charts to remote charts with your awesome plugin.
My charts repository is private (with basic auth) so I discovered when the command tries to pull my chart that it was rejected because of not providing credentials.

I edited the extension to pass credentials to the command (like it is made lower in the code).
However, i have not experience with Python and I do not know if my approach is the good one. But, it works well ! :)

I will be happy to listen your feedback about it and to know what it is the correct solution to fix that.

Thank you for your work !