### PR TITLE
feat: add release_name parameter to helm_remote

### DIFF
--- a/helm_remote/README.md
+++ b/helm_remote/README.md
@@ -19,13 +19,15 @@ helm_remote('myChartName')
 ##### Additional Parameters
 
 ```
-helm_remote(chart_name, repo_url='', repo_name='', namespace='', version='', username='', password='', values=[], set=[])
+helm_remote(chart_name, repo_url='', repo_name='', release_name='', namespace='', version='', username='', password='', values=[], set=[])
 ```
 
 * `chart_name` ( str ) – the name of the chart to install  
 * `repo_name` ( str ) – the name of the repo within which to find the chart (assuming the repo is already added locally)
 <br> if omitted, defaults to the same value as `chart_name`
 * `repo_url` ( str ) – the URL of the repo within which to find the chart (equivalent to `helm repo add <repo_name> <repo_url>`)
+* `release_name` (str) - the name of the helm release
+<br> if omitted, defaults to the same value as `chart_name`
 * `namespace` ( str ) – the namespace to deploy the chart to (equivalent to helm's `--namespace <namespace> --create-namespace` flags)
 * `version` ( str ) – the version of the chart to install. If omitted, defaults to latest version (equivalent to helm's `--version` flag)
 * `username` ( str ) – repository authentication username, if needed (equivalent to helm's `--username` flag)

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -37,10 +37,12 @@ metadata:
 #   =====================================
 
 
-def helm_remote(chart, repo_url='', repo_name='', values=[], set=[], namespace='', version='', username='', password=''):
+def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], set=[], namespace='', version='', username='', password=''):
     # ======== Condition Incoming Arguments
     if repo_name == '':
         repo_name = chart
+    if release_name == '':
+        release_name = chart
     if namespace == '':
         namespace = 'default'
     if repo_url != '':
@@ -87,9 +89,9 @@ def helm_remote(chart, repo_url='', repo_name='', values=[], set=[], namespace='
 
     # TODO: since neither `k8s_yaml()` nor `helm()` accept resource_deps, sometimes the crds haven't yet finished installing before the below tries to run
     if namespace != '':
-        k8s_yaml(helm(chart_target, name=chart, namespace=namespace, values=values, set=set))
+        k8s_yaml(helm(chart_target, name=release_name, namespace=namespace, values=values, set=set))
     else:
-        k8s_yaml(helm(chart_target, name=chart, values=values, set=set))
+        k8s_yaml(helm(chart_target, name=release_name, values=values, set=set))
 
 
 def install_crds(name, directory):


### PR DESCRIPTION
Hello,

I added a new parameter for the function `helm_remote` in case of we need to name a release with a different name of its chart`s name.

My use case is that I have a chart called `base` and i launch two services `myServiceOne` and `myServiceTwo` from this same chart (the chart is the same but `values.yaml` are different.

In the current case, if i give `myServiceOne` as name the script will try to download `myRepo/myServiceOne` while the targeted chart is called `myRepo/base`. With this new option, targeted chart stays `base` but helm function is called with the wanted name. :)

Thank you for your work <3