### PR TITLE
helm_remote: remove specific chart instead of global directory

### DIFF
--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -81,7 +81,7 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
         pull_command += ' --password %s' % password
 
     # ======== Perform Installation
-    local('rm -rf %s' % pull_target)
+    local('rm -rf %s/%s' % (pull_target, chart))
     local(pull_command)
     install_crds(chart, chart_target)
 


### PR DESCRIPTION
Hello,

I noticed that at the end in my local folder `.helm/`, i have not all my remote chart, but only one. It is because the remove command remove the root folder instead of the specific chart. This PR fixes the issue :)

Thank you for your work !