### PR TITLE
tiltfile: added extension to enforce minimum k8s version

### DIFF
--- a/min_k8s_version/README.md
+++ b/min_k8s_version/README.md
@@ -1,0 +1,13 @@
+# Minimum Kubernetes Version
+
+Specify a minimum Kubenetes version to run this TiltFile
+
+If the minimum version is not met, Tilt will stop executing using the `fail` api
+
+## Usage
+
+
+```py
+load('ext://min_k8s_version', 'min_k8s_version')
+min_k8s_version('1.18.3')
+```

--- a/min_k8s_version/Tiltfile
+++ b/min_k8s_version/Tiltfile
@@ -1,0 +1,26 @@
+def min_k8s_version(min_version):
+
+   #This relies on the fact that the shell command returning something in the form 'gitVersion: vX.X.X'
+    version_str =  str(local('kubectl version --client  -o yaml| grep "gitVersion"', quiet=True))
+   
+   #Get the string, separate it at the colon, remove the 'v' and any spaces
+    version_str = version_str.split(':')[1].replace('v','').strip()
+  
+  #David Rubin's helper function returns the version in the form [X, X, X]
+    cur_ver = _version_tuple(version_str)
+    min_ver = _version_tuple(min_version)
+    
+    if cur_ver < min_ver:
+        print(" ---------------------------------------------------------- ")
+        print("|                                                          |")
+        print("|            Minimum Kubernetes Version Not Met!           |")
+        print("|                Refer link below to update                |")
+        print("| https://kubernetes.io/docs/tasks/tools/install-kubectl/  |")
+        print("|                                                          |")
+        print(" ---------------------------------------------------------- ")
+        fail('Minimum Kubernetes Version Not Met! Current Version is %s' % version_str)
+
+# From David Rubin's minimum tilt version extension
+def _version_tuple(v):
+  return [int(str_num) for str_num in v.split(".")]
+

--- a/min_k8s_version/Tiltfile
+++ b/min_k8s_version/Tiltfile
@@ -1,7 +1,7 @@
 def min_k8s_version(min_version):
 
-   #This relies on the fact that the shell command returning something in the form 'Server Version: vX.X.X'
-    version_str =  str(local('kubectl version --short| grep "Server Version"', quiet=True))
+   #This relies on the fact that the shell command returning something in the form 'gitVersion: vX.X.X'
+    version_str =  str(local('kubectl version --short| grep "Server Version"', quiet=True, echo_off=True))
    #Get the string, separate it at the colon, remove the 'v' and any spaces
     version_str = version_str.split(':')[1].replace('v','').strip()
   
@@ -13,8 +13,9 @@ def min_k8s_version(min_version):
         print(" ---------------------------------------------------------- ")
         print("|                                                          |")
         print("|            Minimum Kubernetes Version Not Met!           |")
-        print("|                Refer link below to update                |")
-        print("| https://kubernetes.io/docs/tasks/tools/install-kubectl/  |")
+        print("|                Current Version : v{}                 |".format(version_str))
+        print("|            Minimum Required Version : v{}            |".format(min_version))
+        print("|            Current Kubernetes Cluster : {}         |".format( k8s_context()))
         print("|                                                          |")
         print(" ---------------------------------------------------------- ")
         fail('Minimum Kubernetes Version Not Met! Current Version is %s' % version_str)

--- a/min_k8s_version/Tiltfile
+++ b/min_k8s_version/Tiltfile
@@ -1,8 +1,7 @@
 def min_k8s_version(min_version):
 
-   #This relies on the fact that the shell command returning something in the form 'gitVersion: vX.X.X'
-    version_str =  str(local('kubectl version --client  -o yaml| grep "gitVersion"', quiet=True))
-   
+   #This relies on the fact that the shell command returning something in the form 'Server Version: vX.X.X'
+    version_str =  str(local('kubectl version --short| grep "Server Version"', quiet=True))
    #Get the string, separate it at the colon, remove the 'v' and any spaces
     version_str = version_str.split(':')[1].replace('v','').strip()
   
@@ -23,4 +22,3 @@ def min_k8s_version(min_version):
 # From David Rubin's minimum tilt version extension
 def _version_tuple(v):
   return [int(str_num) for str_num in v.split(".")]
-


### PR DESCRIPTION
Hello @nicks !

Here's the initial idea I came up with for enforcing a minimum tilt version. The functionality is heavily inspired by the min_tilt_version extension. Would something like this address the raised issue? (https://github.com/tilt-dev/tilt/issues/3297) 