### PR TITLE
restart_process: reduce image size

### DIFF
--- a/restart_process/Dockerfile
+++ b/restart_process/Dockerfile
@@ -7,8 +7,8 @@ RUN apk add build-base
 RUN git clone https://github.com/eradman/entr.git /entr
 RUN cd /entr; ./configure; CFLAGS="-static" make install
 
-FROM alpine:3.12
+FROM scratch
 
-COPY --from=0  /usr/local/bin/entr /usr/local/bin/entr
+COPY --from=0  /usr/local/bin/entr /
 
 ADD tilt-restart-wrapper /

--- a/restart_process/Dockerfile
+++ b/restart_process/Dockerfile
@@ -7,4 +7,8 @@ RUN apk add build-base
 RUN git clone https://github.com/eradman/entr.git /entr
 RUN cd /entr; ./configure; CFLAGS="-static" make install
 
+FROM alpine:3.12
+
+COPY --from=0  /usr/local/bin/entr /usr/local/bin/entr
+
 ADD tilt-restart-wrapper /


### PR DESCRIPTION
Previous size (measured with `docker image inspect aaaaaa --format '{{.Size}}'`):
240996873 bytes = 240 MB

New size:
8546985 bytes = 8.5 MB