### PR TITLE
helm_remote: filter out crds w/ `{{` instead of `{{-`; try to add some clarifying comments

### DIFF
--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -93,6 +93,7 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
     else:
         k8s_yaml(helm(chart_target, name=release_name, values=values, set=set))
 
+# install CRDs as a separate resource and wait for them to be ready
 def install_crds(name, directory):
     name += '-crds'
     files = str(local(r"grep --include '*.yaml' --include '*.yml' -rEil '\bkind\s*:\s+CustomResourceDefinition\s*$' %s || true" % directory)).strip()
@@ -102,8 +103,11 @@ def install_crds(name, directory):
     else:
         files = files.split("\n")
 
-    # If the CRD files contain any Helm preprocessing, skip them.
-    files = [f for f in files if str(read_file(f)).find('{{-') == -1]
+    # we're applying CRDs directly and not using helm preprocessing
+    # this will cause errors!
+    # since installing CRDs in this function is a nice-to-have, just skip
+    # any that have preprocessing
+    files = [f for f in files if str(read_file(f)).find('{{') == -1]
 
     if len(files) != 0:
         local_resource(name+'-install', cmd='kubectl apply -f %s' % " -f ".join(files), deps=files)  # we can wait/depend on this, but it won't cause a proper uninstall


### PR DESCRIPTION
fix #67 

cc @KOGI 

I'm not very familiar with this extension and have made some guesses and tried to add comments to document my understanding. I'd like corrections if I'm wrong!

From the [helm docs](https://helm.sh/docs/chart_template_guide/control_structures/):
> {{- (with the dash and space added) indicates that whitespace should be chomped left

I can't think of a reason to filter by templates that happen to be doing whitespace chomping and I'm guessing it just happened that a crd encountered during development was doing chomping.