### PR TITLE
[secret] add ability to specify the type of secret

### DIFF
--- a/secret/Tiltfile
+++ b/secret/Tiltfile
@@ -1,6 +1,6 @@
 # -*- mode: Python -*-
 
-def secret_yaml_generic(name, namespace="", from_file=None):
+def secret_yaml_generic(name, namespace="", from_file=None, secret_type=None):
   """Returns YAML for a generic secret
 
   Args:
@@ -8,6 +8,8 @@ def secret_yaml_generic(name, namespace="", from_file=None):
     namespace: The namespace.
     from_file: Use the from-file secret generator. May be a string or a list of strings.
        Example: ["ssh--privatekey=path/to/id_rsa", "ssh-publickey=path/to/id_rsa.pub"]
+    secret_type (optional): Specify the type of the secret
+      Example: 'kubernetes.io/dockerconfigjson'
 
   Returns:
     The secret YAML as a blob
@@ -38,17 +40,25 @@ def secret_yaml_generic(name, namespace="", from_file=None):
 
   if not generator:
     fail("No secret generator specified")
+  
+  if secret_type:
+    if type(secret_type) == "string":
+      args.extend(["--type", secret_type])
+    else:
+      fail("Bad secret_type argument: %s" % secret_type)
 
   args.extend(["-o=yaml", "--dry-run=client"])
   return local(args)
 
-def secret_create_generic(name, namespace="", from_file=None):
+def secret_create_generic(name, namespace="", from_file=None, secret_type=None):
   """Creates a secret in the current Kubernetes cluster.
 
   Args:
     name: The secret name.
     namespace: The namespace.
     from_file: Use the from-file secret generator. May be a string or a list of strings.
-       Example: ["ssh--privatekey=path/to/id_rsa", "ssh-publickey=path/to/id_rsa.pub"]
+      Example: ["ssh--privatekey=path/to/id_rsa", "ssh-publickey=path/to/id_rsa.pub"]
+    secret_type (optional): Specify the type of the secret
+      Example: 'kubernetes.io/dockerconfigjson'
   """
-  k8s_yaml(secret_yaml_generic(name, namespace, from_file))
+  k8s_yaml(secret_yaml_generic(name, namespace, from_file, secret_type))


### PR DESCRIPTION
Hello,

I added an option on secret extension to specify the type of secret. Indeed, this is necessary for `docker-registry` secret to be detected and correctly work. :)

It seems to be good with me. Any feedback is welcome !

Thank you for your work !