### PR TITLE
helm_remote: allow charts with duplicate yaml

### DIFF
--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -37,7 +37,7 @@ metadata:
 #   =====================================
 
 
-def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], set=[], namespace='', version='', username='', password=''):
+def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], set=[], namespace='', version='', username='', password='', allow_duplicates=False):
     # ======== Condition Incoming Arguments
     if repo_name == '':
         repo_name = chart
@@ -87,11 +87,23 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
 
     install_crds(chart, chart_target)
 
-    # TODO: since neither `k8s_yaml()` nor `helm()` accept resource_deps, sometimes the crds haven't yet finished installing before the below tries to run
-    if namespace != '':
-        k8s_yaml(helm(chart_target, name=release_name, namespace=namespace, values=values, set=set))
+    # TODO: since neither `k8s_yaml()` nor `helm()` accept resource_deps,
+    # sometimes the crds haven't yet finished installing before the below tries
+    # to run
+    yaml = helm(chart_target, name=release_name, namespace=namespace, values=values, set=set)
+
+    # The allow_duplicates API is only available in 0.17.1+
+    if allow_duplicates and _version_tuple() >= [0, 17, 1]:
+        k8s_yaml(yaml, allow_duplicates=allow_duplicates)
     else:
-        k8s_yaml(helm(chart_target, name=release_name, values=values, set=set))
+        k8s_yaml(yaml)
+
+def _version_tuple():
+  ver_string = str(local('tilt version', quiet=True))
+  versions = ver_string.split(', ')
+  # pull first string and remove the `v` and `-dev`
+  version = versions[0].replace('-dev', '').replace('v', '')
+  return [int(str_num) for str_num in version.split(".")]
 
 # install CRDs as a separate resource and wait for them to be ready
 def install_crds(name, directory):

--- a/helm_remote/test/Tiltfile
+++ b/helm_remote/test/Tiltfile
@@ -7,7 +7,10 @@ if not os.path.exists('./.helm/memcached'):
   fail('memcached failed to load in the right directory')
 
 # This chart has a bunch of CRDs (including templated CRDs), so we can test the CRD init logic.
-helm_remote('gloo', repo_url='https://storage.googleapis.com/solo-public-helm')
+helm_remote('gloo', repo_url='https://storage.googleapis.com/solo-public-helm',
+            # The gloo chart has duplicate resources, see discussion here:
+            # https://github.com/tilt-dev/tilt/issues/3656
+            allow_duplicates=True)
 
 docker_build('helm-remote-test-verify', '.')
 k8s_yaml('job.yaml')

--- a/min_tilt_version/Tiltfile
+++ b/min_tilt_version/Tiltfile
@@ -8,7 +8,7 @@ def min_tilt_version(min_version):
   # Clean out the version file so its in the format 0.13.0
   versions = ver_string.split(', ')
   # pull first string and remove the `v` and `-dev`
-  version = versions[0].replace('v', '').replace('-dev', '')
+  version = versions[0].replace('-dev', '').replace('v', '')
 
   # Python allows you to compare two tuples
   # (0, 12, 0) < (0, 12, 1)


### PR DESCRIPTION
Hello @landism, @kogi,

Please review the following commits I made in branch nicks/duplicate:

5398d7c7a7f3f7275771f1944902dc3602cba299 (2020-08-13 10:07:13 -0400)
helm_remote: allow charts with duplicate yaml
also fix the version checks for dev builds

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics