### PR TITLE
extensions: use more specific image suffix

### DIFF
--- a/docker_build_sub/Tiltfile
+++ b/docker_build_sub/Tiltfile
@@ -1,4 +1,4 @@
-def docker_build_sub(ref, context, extra_cmds, child_context=None, base_suffix='-base', live_update=[], **kwargs):
+def docker_build_sub(ref, context, extra_cmds, child_context=None, base_suffix='-tilt_docker_build_sub_base', live_update=[], **kwargs):
   """
   Substitutes in a docker image with extra Dockerfile commands.
 

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -12,7 +12,7 @@ KWARGS_BLACKLIST = [
 ]
 
 def docker_build_with_restart(ref, context, entrypoint, live_update,
-                              base_suffix='-base', restart_file=RESTART_FILE, **kwargs):
+                              base_suffix='-tilt_docker_build_with_restart_base', restart_file=RESTART_FILE, **kwargs):
     """Wrap a docker_build call and its associated live_update steps so that the last step
     of any live update is to rerun the given entrypoint.
 


### PR DESCRIPTION
### Problem

The `docker_build_sub` and `docker_build_with_restart` extensions work by appending a suffix to an existing image to rename it, and then defining a new image with the original name, starting from that renamed image.

The default suffix used is "-base", which is kind of a logical suffix for users to take for themselves. If they already have an image by that name, they get a confusing error message like `Image dependency cycle: docker.registry.domain.com/my-project-base`, which doesn't give them a lot to go on, especially since theoretically this base image is an implementation detail of the extension and they shouldn't need to know about it.

### Solution

Change the default suffix to something that:
1. is far less likely to conflict with any existing image names
2. makes it more likely that a user seeing the image name w/ suffix is going to be able to realize that one of these extensions is a factor (whether because they got an error or they're just curious where this image magically came from)