### PR TITLE
add coreos_prometheus to the extensions readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ All extensions have been vetted and approved by the Tilt team.
 
 - [`api_server_logs`](/api_server_logs): Print API server logs. Example from [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).
 - [`conftest`](/conftest): Use [Conftest](https://www.conftest.dev/) to test your configuration files.
+- [`coreos_prometheus`](/coreos_prometheus): Deploys Prometheus to a monitoring namespace, managed by the CoreOS Prometheus Operator and CRDs
 - [`docker_build_sub`](/docker_build_sub): Specify extra Dockerfile directives in your Tiltfile beyond [`docker_build`](https://docs.tilt.dev/api.html#api.docker_build).
 - [`file_sync_only`](/file_sync_only): No-build, no-push, file sync-only development. Useful when you want to live-reload a single config file into an existing public image, like nginx.
 - [`git_resource`](/git_resource): Deploy a dockerfile from a remote repository -- or specify the path to a local checkout for local development.


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/prom:

ddfef808bc9f55cf4bd8ec85e4e56be374e4972c (2020-09-16 18:43:41 -0400)
add coreos_prometheus to the extensions readme

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics