### PR TITLE
Initialize and update submodules during git checkout

### DIFF
--- a/git_resource/Tiltfile
+++ b/git_resource/Tiltfile
@@ -40,7 +40,7 @@ def git_checkout(repository_url, checkout_dir=None, unsafe_mode=False):
 
     if config.tilt_subcommand == "up" or config.tilt_subcommand == "ci":
         if not os.path.exists(checkout_dir):  # needs clone
-            local('git clone %s -b %s %s' % (repository_url, branch, checkout_dir), quiet=True)
+            local('git clone --recurse-submodules %s -b %s %s' % (repository_url, branch, checkout_dir), quiet=True)
         else:  # dir already exists
             if os.path.exists('%s/.git' % checkout_dir):  # this is a git repo
                 has_local_changes = True  # default to True for safety
@@ -48,7 +48,7 @@ def git_checkout(repository_url, checkout_dir=None, unsafe_mode=False):
                     has_local_changes = int(str(local('cd %s && git status -sbuno | wc -l' % checkout_dir, quiet=True)).strip()) > 1  # result greater than 1 indicates local modifications are present
 
                 if unsafe_mode or not has_local_changes:
-                    local('cd %s && git fetch -a origin && git checkout -f %s' % (checkout_dir, branch), quiet=True)
+                    local('cd %s && git fetch -a origin && git checkout -f %s && git submodule update --init' % (checkout_dir, branch), quiet=True)
                 else:
                     fail('git_checkout() failed: local modifications present and safe_mode is enabled')
 


### PR DESCRIPTION
Hi. Some of our git repos use submodules. This change makes sure that submodules are always up to date (and as no effect on repos without submodules).

Something you guys would be open to merging upstream?