### PR TITLE
Checkout fetched branch from origin on git update

### DIFF
--- a/git_resource/Tiltfile
+++ b/git_resource/Tiltfile
@@ -48,7 +48,7 @@ def git_checkout(repository_url, checkout_dir=None, unsafe_mode=False):
                     has_local_changes = int(str(local('cd %s && git status -sbuno | wc -l' % checkout_dir, quiet=True)).strip()) > 1  # result greater than 1 indicates local modifications are present
 
                 if unsafe_mode or not has_local_changes:
-                    local('cd %s && git fetch -a origin && git checkout -f %s && git submodule update --init' % (checkout_dir, branch), quiet=True)
+                    local('cd %s && git fetch -a origin && git checkout -f origin/%s && git submodule update --init' % (checkout_dir, branch), quiet=True)
                 else:
                     fail('git_checkout() failed: local modifications present and safe_mode is enabled')
 


### PR DESCRIPTION
Another small pain point. At least with my git configuration, checking out a branch by name only checks out my local branch and not the one we just fetched from `origin`. So, it still needs a `git pull` to update after checkout or the code is still on my last-merged/fetched commit. This change just makes sure we always check out the `origin/*` ref for the branch that was just fetched.