### PR TITLE
Add cert-manager extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is the official Tilt Extensions Repository. Read more in [docs](https://doc
 All extensions have been vetted and approved by the Tilt team.
 
 - [`api_server_logs`](/api_server_logs): Print API server logs. Example from [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).
+- [`cert-manager`](/cert-manager): Deploys cert-manager.
 - [`conftest`](/conftest): Use [Conftest](https://www.conftest.dev/) to test your configuration files.
 - [`coreos_prometheus`](/coreos_prometheus): Deploys Prometheus to a monitoring namespace, managed by the CoreOS Prometheus Operator and CRDs
 - [`docker_build_sub`](/docker_build_sub): Specify extra Dockerfile directives in your Tiltfile beyond [`docker_build`](https://docs.tilt.dev/api.html#api.docker_build).

--- a/cert_manager/README.md
+++ b/cert_manager/README.md
@@ -1,0 +1,26 @@
+# Cert-manager
+
+This extension deploys cert-manager.
+
+## Usage
+
+Basic usage
+
+```
+load('ext://cert_manager', 'deploy_cert_manager')
+
+deploy_cert_manager()
+```
+
+This will deploy cert-manager to you cluster and checks it actually works.
+
+If working with Kind, its is possible to pass `load_to_kind=True` to `deploy_cert_manager` so
+all the cert-manager images will be pre-pulled to your local environment and then loaded into Kind before installing. 
+This speeds up your workflow if you're repeatedly destroying and recreating your kind cluster, as it doesn't
+have to pull the images over the network each time.
+
+The full list of parameters accepted by `deploy_cert_manager` includes:
+- `registry` from which images should be pulled, defaults to `quay.io/jetstack`
+- `version` of cert-manager to install, defaults to `v0.16.1`
+- `load_to_kind` (see above), defaults to `False`
+- `kind_cluster_name`, defaults to `kind`

--- a/cert_manager/Tiltfile
+++ b/cert_manager/Tiltfile
@@ -1,0 +1,62 @@
+cert_manager_test_resources = """
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-test
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: test-selfsigned
+  namespace: cert-manager-test
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: selfsigned-cert
+  namespace: cert-manager-test
+spec:
+  dnsNames:
+    - example.com
+  secretName: selfsigned-cert-tls
+  issuerRef:
+    name: test-selfsigned
+"""
+
+# Deploys cert manager to your environment
+def deploy_cert_manager(registry="quay.io/jetstack", version="v0.16.1", load_to_kind=False, kind_cluster_name="kind"):
+    silent=True
+
+    # check if cert-mamager is already installed, otherwise pre-load images & apply the manifest
+    # NB. this is required until https://github.com/jetstack/cert-manager/issues/3121 is addressed otherwise
+    # when applying the manifest twice to same cluster kubectl get stuck
+    existsCheck = str(local("kubectl get namespaces", quiet=silent, echo_off=silent))
+    if existsCheck.find("cert-manager") == -1:
+        if load_to_kind == True:
+            print("Loading images to kind")
+            # Prepull all the cert-manager images to your local environment and then load them directly into kind. This speeds up
+            # setup if you're repeatedly destroying and recreating your kind cluster, as it doesn't have to pull the images over
+            # the network each time.
+            images = ["cert-manager-controller", "cert-manager-cainjector", "cert-manager-webhook"]
+            for image in images:
+                local("docker pull {}/{}:{}".format(registry, image, version), quiet=silent, echo_off=silent)
+                local("kind load docker-image --name {} {}/{}:{}".format(kind_cluster_name, registry, image, version), quiet=silent, echo_off=silent)
+
+        # apply the cert-manager manifest
+        print("Installing cert-manager")
+        local("kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/{}/cert-manager.yaml".format(version), quiet=silent, echo_off=silent)
+
+    # verifies cert-manager is properly working (https://cert-manager.io/docs/installation/kubernetes/#verifying-the-installation)
+    # 1. wait for the cert-manager to be running
+    print("Waiting for cert-manager to start")
+    local("kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager", quiet=silent, echo_off=silent)
+    local("kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager-cainjector", quiet=silent, echo_off=silent)
+    local("kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager-webhook", quiet=silent, echo_off=silent)
+
+    # 2. create a test certificate
+    print("Testing cert-manager")
+    local("cat << EOF | kubectl apply -f - " + cert_manager_test_resources + "EOF", quiet=silent, echo_off=silent)
+    local("kubectl wait --for=condition=Ready --timeout=300s -n cert-manager-test certificate/selfsigned-cert ", quiet=silent, echo_off=silent)
+    local("cat << EOF | kubectl delete -f - " + cert_manager_test_resources + "EOF", quiet=silent, echo_off=silent)


### PR DESCRIPTION
Add an extension for deploying cert-manager and wait to it for being properly working by following the process described in the cert-manager documentation (https://cert-manager.io/docs/installation/kubernetes/#verifying-the-installation)

A working instance of cert-manager is required before calling `k8s_yaml` for any controller developed with Kubebuilder/using validation webhooks.

This extension makes it easier to get a working instance of cert-manager in the Tiltfile of all these projects

@victorwuky