### PR TITLE
Add wait_for_it extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`restart_process`](/restart_process): Wrap a `docker_build` to restart the given entrypoint after a Live Update (replaces `restart_container()`)
 - [`secret`](/secret): Functions for creating secrets.
 - [`snyk`](/snyk): Use [Snyk](https://snyk.io) to test your configuration files.
+- [`wait_for_it`](/wait_for_it): Wait until command output is equal to given output.
 
 ## Contribute an Extension
 

--- a/wait_for_it/README.md
+++ b/wait_for_it/README.md
@@ -1,0 +1,35 @@
+# local_output
+
+Author: [Çağatay Yücelen](https://github.com/cyucelen)
+
+Wait until command output is equal to given output.
+
+`wait_for_it` runs given command and checks if output is equal to expected output. Retry limit and backoff time can be specified.
+This extension can be useful in situations like waiting for your server, database is healthy.
+
+
+## Usage
+
+Pass a command and expected output to wait until your expectation met.
+
+### Example:
+
+```python
+wait_for_it('minikube status | grep Running | wc -l | tr -d " "', expected_output='3')
+```
+
+Original `minikube status` command output:
+```
+m01
+host: Running
+kubelet: Running
+apiserver: Running
+kubeconfig: Configured
+```
+
+### Arguments:
+
+- `command`: shell command to execute and get output
+- `expected_output`: output value to retry until met
+- `backoff`: sleep duration between retries
+- `retry_limit`: count of total retries before fail

--- a/wait_for_it/README.md
+++ b/wait_for_it/README.md
@@ -1,4 +1,4 @@
-# local_output
+# wait_for_it
 
 Author: [Çağatay Yücelen](https://github.com/cyucelen)
 

--- a/wait_for_it/Tiltfile
+++ b/wait_for_it/Tiltfile
@@ -1,0 +1,29 @@
+def local_output(command):
+  return str(local(command, echo_off=True, quiet=True)).rstrip('\n')
+
+ordinals = {
+  1: 'st',
+  2: 'nd',
+  3: 'rd',
+}
+
+def print_status(retry_count, expected_output, actual_output):
+    print('{}{} retry'.format(retry_count, ordinals.get(retry_count, 'th')))
+    print('-----------------------')
+    print('| Expected output: {}'.format(expected_output))
+    print('| Actual output  : {}'.format(actual_output))
+    print('-----------------------')
+
+def wait_for_it(command, expected_output, backoff=1000, retry_limit=5):
+  print('+--+-+-+-+-+-+-+-+-+-+-+')
+  print('Waiting for \'{}\' to output: \'{}\''.format(command, expected_output))
+  for i in range(retry_limit):
+    actual_output = local_output(command)
+    print_status(i+1, expected_output, actual_output)
+    if actual_output == expected_output:
+      print('Output expectation successfully met!')
+      return
+    print('Sleeping for {}ms'.format(backoff))
+    local('sleep {}'.format(backoff//1000), quiet=True, echo_off=True)
+    print('\n+--+-+-+-+-+-+-+-+-+-+-+\n')
+  fail('Retry limit exceeded!')


### PR DESCRIPTION
This extension can be useful in situations like waiting for some service until it is healthy/ready.

_if you decide to approve this PR, i would be so happy if you label it as `hacktoberfest-accepted`_. 

Happy Hacktober!