### PR TITLE
restart_process: use our fork of entr to return exit code of user command

### DIFF
--- a/restart_process/Dockerfile
+++ b/restart_process/Dockerfile
@@ -3,8 +3,9 @@ FROM alpine/git
 RUN apk update && apk add make
 RUN apk add build-base
 
-RUN git clone https://github.com/tilt-dev/entr.git /entr
+RUN git clone https://github.com/eradman/entr.git /entr
 WORKDIR /entr
+RUN git checkout c564e6bdca1dfe2177d1224363cad734158863ad
 RUN ./configure; CFLAGS="-static" make install
 
 FROM scratch

--- a/restart_process/Dockerfile
+++ b/restart_process/Dockerfile
@@ -3,9 +3,9 @@ FROM alpine/git
 RUN apk update && apk add make
 RUN apk add build-base
 
-# TODO(maia): specify commit instead of just using latest master?
-RUN git clone https://github.com/eradman/entr.git /entr
-RUN cd /entr; ./configure; CFLAGS="-static" make install
+RUN git clone https://github.com/tilt-dev/entr.git /entr
+WORKDIR /entr
+RUN ./configure; CFLAGS="-static" make install
 
 FROM scratch
 

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -42,7 +42,7 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
     # declare a new docker build that adds a static binary of tilt-restart-wrapper
     # (which makes use of `entr` to watch files and restart processes) to the user's image
     df = '''
-    FROM tiltdev/restart-helper:2020-07-16 as restart-helper
+    FROM tiltdev/restart-helper:2020-10-15 as restart-helper
 
     FROM {}
     USER root

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -42,7 +42,7 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
     # declare a new docker build that adds a static binary of tilt-restart-wrapper
     # (which makes use of `entr` to watch files and restart processes) to the user's image
     df = '''
-    FROM tiltdev/restart-helper:2020-10-15 as restart-helper
+    FROM tiltdev/restart-helper:2020-10-16 as restart-helper
 
     FROM {}
     USER root

--- a/restart_process/release.sh
+++ b/restart_process/release.sh
@@ -12,7 +12,7 @@ env GOOS=linux GOARCH=amd64 go build tilt-restart-wrapper.go
 # build Docker image with static binaries of:
 # - tilt-restart-wrapper (compiled above)
 # - entr (dependency of tilt-restart-wrapper)
-docker build . -t $IMAGE_NAME
+docker build . -t $IMAGE_NAME --no-cache
 docker push $IMAGE_NAME
 
 docker tag $IMAGE_NAME $IMAGE_WITH_TAG

--- a/restart_process/release.sh
+++ b/restart_process/release.sh
@@ -12,7 +12,7 @@ env GOOS=linux GOARCH=amd64 go build tilt-restart-wrapper.go
 # build Docker image with static binaries of:
 # - tilt-restart-wrapper (compiled above)
 # - entr (dependency of tilt-restart-wrapper)
-docker build . -t $IMAGE_NAME --no-cache
+docker build . -t $IMAGE_NAME
 docker push $IMAGE_NAME
 
 docker tag $IMAGE_NAME $IMAGE_WITH_TAG

--- a/restart_process/test/Dockerfile
+++ b/restart_process/test/Dockerfile
@@ -1,0 +1,5 @@
+FROM busybox
+
+COPY fail.sh /
+
+ENTRYPOINT /fail.sh

--- a/restart_process/test/Tiltfile
+++ b/restart_process/test/Tiltfile
@@ -1,0 +1,5 @@
+load('../Tiltfile', 'docker_build_with_restart')
+
+k8s_yaml('job.yaml')
+docker_build_with_restart('failing_job', '.', '/fail.sh',
+                          live_update=[sync('./fail.sh', '/fail.sh')])

--- a/restart_process/test/fail.sh
+++ b/restart_process/test/fail.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+
+echo "Are you there, pod?"
+sleep 1
+
+# Exit with a non-zero status code; we check that docker_build_with_restart
+# surfaces this error code to k8s, so k8s knows that the job failed.
+echo "Exiting with status code 123 😱"
+exit 123

--- a/restart_process/test/job.yaml
+++ b/restart_process/test/job.yaml
@@ -1,0 +1,12 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: failing-job
+spec:
+  template:
+    spec:
+      containers:
+        - name: failing-job
+          image: failing_job
+      restartPolicy: Never
+  backoffLimit: 4

--- a/restart_process/test/test.sh
+++ b/restart_process/test/test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Test case for https://github.com/tilt-dev/tilt-extensions/issues/92
+#
+# This job will always exit with a non-zero status code; make sure
+# that docker_build_with_restart surfaces this error code to k8s,
+# so k8s knows that the job failed. (Thus, we expect the `tilt ci`
+# call to fail.)
+cd $(dirname $0)
+
+set -x
+tilt ci > tilt.log 2>&1
+CI_EXIT=$?
+
+tilt down
+
+if [ $CI_EXIT -eq 0 ]; then
+  echo "Expected 'tilt ci' to fail, but succeeded."
+  exit 1
+fi
+
+cat tilt.log | grep -q "Are you there, pod?"
+GREP_EXIT=$?
+
+rm tilt.log
+
+exit $GREP_EXIT

--- a/test.sh
+++ b/test.sh
@@ -8,3 +8,4 @@ git_resource/test/test.sh
 namespace/test/test.sh
 helm_remote/test/test.sh
 secret/test/test.sh
+restart_process/test/test.sh


### PR DESCRIPTION
Addresses https://github.com/tilt-dev/tilt-extensions/issues/92

([Our fork of entr is here](https://github.com/tilt-dev/entr))

Test case: https://github.com/tilt-dev/failing-job