### PR TITLE
snyk: add additional testing capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`procfile`](/procfile): Create Tilt resources from a foreman Procfile.
 - [`restart_process`](/restart_process): Wrap a `docker_build` to restart the given entrypoint after a Live Update (replaces `restart_container()`)
 - [`secret`](/secret): Functions for creating secrets.
-- [`snyk`](/snyk): Use [Snyk](https://snyk.io) to test your configuration files.
+- [`snyk`](/snyk): Use [Snyk](https://snyk.io) to test your containers, configuration files, and open source dependencies.
 - [`wait_for_it`](/wait_for_it): Wait until command output is equal to given output.
 
 ## Contribute an Extension

--- a/snyk/README.md
+++ b/snyk/README.md
@@ -11,7 +11,7 @@ The `snyk` extension can be run like so:
 ```python
 load('ext://snyk', 'snyk')
 
-snyk('kubernetes.yaml')
+snyk('iac-test', 'kubernetes.yaml', 'iac')
 k8s_yaml('kubernetes.yaml')
 k8s_resource('example',
     port_forwards=8000,
@@ -19,10 +19,17 @@ k8s_resource('example',
 )
 ```
 The function takes a number of arguments.
-
-* `path`: path to file to test
-* `name`: a name for the resource, defaults to snyk. Useful if you want multiple invocations
+      name: a name for the resource. useful for labeling when running multiple tests.
+      path: path to the file or container image name:tag to test
+      test_type: one of 'oss', 'container', or 'iac' corresponding to the various Snyk CLI tests
+      k8s_resource: used for container tests - sets the re-test dependency. ignored by other test types.
+      *options: additional CLI options; appended to the snyk command. see `snyk --help` for usage.
+          - container: this is where to insert the 'file==path/to/Dockerfile' option
 
 ## Requirements
 
 * The `snyk` binary must be on your path
+
+
+## Other notes
+The re-test is currently set to manual. That way you only run the Snyk tests when you're ready.

--- a/snyk/README.md
+++ b/snyk/README.md
@@ -1,6 +1,7 @@
 # Use Snyk to test your configuration files
 
 Author: [Shai Mendel](https://github.com/shaimendel)
+* Additional contributor: [Jim Armstrong](https://github.com/jimcodified)
 
 [Snyk](https://https://snyk.io/) is a product to help developers to continuously find and fix vulnerabilities in open source libraries, containers and Infrastructure as Code configurations.
 
@@ -11,25 +12,32 @@ The `snyk` extension can be run like so:
 ```python
 load('ext://snyk', 'snyk')
 
-snyk('iac-test', 'kubernetes.yaml', 'iac')
+docker_build('myimage:v1','.')
+
+snyk('myimage:v1', 'container', 'snyk-cnr', 'example', '--file=Dockerfile')
+snyk('deployment.yaml', 'iac', 'snyk-iac')
+
 k8s_yaml('kubernetes.yaml')
 k8s_resource('example',
     port_forwards=8000,
     resource_deps=['snyk'],
 )
 ```
-The function takes a number of arguments.
-      name: a name for the resource. useful for labeling when running multiple tests.
-      path: path to the file or container image name:tag to test
-      test_type: one of 'oss', 'container', or 'iac' corresponding to the various Snyk CLI tests
-      k8s_resource: used for container tests - sets the re-test dependency. ignored by other test types.
-      *options: additional CLI options; appended to the snyk command. see `snyk --help` for usage.
-          - container: this is where to insert the 'file==path/to/Dockerfile' option
+
+The function takes a number of arguments:
+
+* **path**: path to the file or container image name:tag to test
+* **test_type**: one of 'oss', 'container', or 'iac' corresponding to the various Snyk CLI tests
+* **name**: a name for the resource. useful for labeling when running multiple tests. Defaults to 'snyk'.
+* **k8s_dep**: used for test_type=='container' and sets Tilt re-test dependency. Ignored by other test types.
+* ***options**: additional CLI options; appended to the snyk command. see `snyk --help` for CLI options.
+  * container: this is where to insert the 'file==path/to/Dockerfile' option
+  * ' --severity-threshold=[high|medium|low]' is another useful consideration
 
 ## Requirements
 
 * The `snyk` binary must be on your path
 
-
 ## Other notes
-The re-test is currently set to manual. That way you only run the Snyk tests when you're ready.
+
+The re-test is currently set to manual. The first tests will be run automatically when you `tilt up` but subsequent tests need to be started manually so you only run the Snyk tests  when you're ready.

--- a/snyk/README.md
+++ b/snyk/README.md
@@ -30,7 +30,7 @@ The function takes a number of arguments:
 * **test_type**: one of 'oss', 'container', or 'iac' corresponding to the various Snyk CLI tests
 * **name**: a name for the resource. useful for labeling when running multiple tests. Defaults to 'snyk'.
 * **k8s_dep**: used for test_type=='container' and sets Tilt re-test dependency. Ignored by other test types.
-* ***options**: additional CLI options; appended to the snyk command. see `snyk --help` for CLI options.
+* **extra_opts**: additional CLI options; appended to the snyk command. see `snyk --help` for CLI options.
   * container: this is where to insert the 'file==path/to/Dockerfile' option
   * ' --severity-threshold=[high|medium|low]' is another useful consideration
 

--- a/snyk/Tiltfile
+++ b/snyk/Tiltfile
@@ -1,13 +1,13 @@
 
-def snyk(name, path, test_type, k8s_resource, *options):
+def snyk(path, test_type, name='snyk', k8s_dep='', *options):
     """
     Args:
-      name: a name for the resource. useful for labeling when running multiple tests.
-      path: path to the file or container image name:tag to test
+      path: path to the file or container image (name:tag) to test
       test_type: one of 'oss', 'container', or 'iac' corresponding to the various Snyk CLI tests
-      k8s_resource: used for container tests - sets the re-test dependency. ignored by other test types.
-      *options: additional CLI options; appended to the snyk command. see `snyk --help` for usage.
-          - container: this is where to insert the 'file==path/to/Dockerfile' option
+      name: a name for the resource. useful for labeling when running multiple tests. defaults to 'snyk'
+      k8s_dep: used for container tests - sets the re-test dependency for Tilt. Ignored by other test types.
+      *options: additional CLI options; appended to the snyk command. see `snyk --help` for full CLI options.
+          - container: this is where to insert the 'file=path/to/Dockerfile' option
     """
     if test_type == 'oss':
         snyk_cmd = " ".join([
@@ -20,7 +20,7 @@ def snyk(name, path, test_type, k8s_resource, *options):
             "snyk container test",
             path
         ])
-        test_deps = [k8s_resource]
+        test_deps = [k8s_dep]
     elif test_type == 'iac':
         snyk_cmd = " ".join([
             "snyk iac test",

--- a/snyk/Tiltfile
+++ b/snyk/Tiltfile
@@ -1,12 +1,11 @@
-
-def snyk(path, test_type, name='snyk', k8s_dep='', *options):
+def snyk(path, test_type, name='snyk', k8s_dep='', extra_opts=''):
     """
     Args:
-      path: path to the file or container image (name:tag) to test
+      name: a name for the resource. useful for labeling when running multiple tests.
+      path: path to the file or container image name:tag to test
       test_type: one of 'oss', 'container', or 'iac' corresponding to the various Snyk CLI tests
-      name: a name for the resource. useful for labeling when running multiple tests. defaults to 'snyk'
-      k8s_dep: used for container tests - sets the re-test dependency for Tilt. Ignored by other test types.
-      *options: additional CLI options; appended to the snyk command. see `snyk --help` for full CLI options.
+      k8s_resource: used for container tests - sets the re-test dependency. ignored by other test types.
+      extra_opts: additional CLI options; appended to the snyk command. see `snyk --help` for usage.
           - container: this is where to insert the 'file=path/to/Dockerfile' option
     """
     if test_type == 'oss':
@@ -28,10 +27,10 @@ def snyk(path, test_type, name='snyk', k8s_dep='', *options):
         ])
         test_deps = [path]
     else:
-        print("Test type should be one of oss, container, or iac.")
+        fail("Snyk test_type should be one of oss, container, or iac.")
 
-    if (len(options) > 0):
-        snyk_cmd = " ".join([snyk_cmd, options[0]])
+    if (len(extra_opts) > 0):
+        snyk_cmd = " ".join([snyk_cmd, extra_opts])
 
     local_resource(
         name,

--- a/snyk/Tiltfile
+++ b/snyk/Tiltfile
@@ -1,11 +1,41 @@
-def snyk(path, name='snyk'):
+
+def snyk(name, path, test_type, k8s_resource, *options):
     """
     Args:
-      path: path to file to test
-      name: a name for the resource, defaults to snyk. Useful if you want multiple invocations
+      name: a name for the resource. useful for labeling when running multiple tests.
+      path: path to the file or container image name:tag to test
+      test_type: one of 'oss', 'container', or 'iac' corresponding to the various Snyk CLI tests
+      k8s_resource: used for container tests - sets the re-test dependency. ignored by other test types.
+      *options: additional CLI options; appended to the snyk command. see `snyk --help` for usage.
+          - container: this is where to insert the 'file==path/to/Dockerfile' option
     """
+    if test_type == 'oss':
+        snyk_cmd = " ".join([
+            "snyk test --all-projects",
+            path
+        ])
+        test_deps = [path]
+    elif test_type == 'container':
+        snyk_cmd = " ".join([
+            "snyk container test",
+            path
+        ])
+        test_deps = [k8s_resource]
+    elif test_type == 'iac':
+        snyk_cmd = " ".join([
+            "snyk iac test",
+            path
+        ])
+        test_deps = [path]
+    else:
+        print("Test type should be one of oss, container, or iac.")
+
+    if (len(options) > 0):
+        snyk_cmd = " ".join([snyk_cmd, options[0]])
+
     local_resource(
         name,
-        deps=[path],
-        cmd= 'snyk iac test %s' % (path)
+        deps = test_deps,
+        cmd = snyk_cmd,
+        trigger_mode=TRIGGER_MODE_MANUAL
     )


### PR DESCRIPTION
This expands upon the original `snyk` extension by adding the following capabilities:

* Added the ability to run container and open source tests, in addition to iac tests
* Ability to supply additional options to the Snyk CLI
* Tests are set to TRIGGER_MODE_MANUAL so as to not fire off tests for every code change

@victorwuky
@shaimendel 