### PR TITLE
variable name fix for min_k8_version tilt file

### DIFF
--- a/min_k8s_version/Tiltfile
+++ b/min_k8s_version/Tiltfile
@@ -28,7 +28,7 @@ def _version_tuple(v):
   if len(v) == 0:
     return ret
 
-  cur_part_is_number = s[0].isdigit()
+  cur_part_is_number = v[0].isdigit()
   cur_part = ''
   for c in v.elems():
     if c.isdigit() != cur_part_is_number:


### PR DESCRIPTION
issue: 

A variable is incorrectly named in the min_k8s_version Tiltfile. Because of this below error is received when `tilt up` is executed. 

```
~# tilt up
Tilt started on http://localhost:10350/
v0.17.9, built 2020-10-19

(space) to open the browser
(s) to stream logs (--stream=true)
(t) to open legacy terminal mode (--legacy=true)
(ctrl-c) to exit
Tilt started on http://localhost:10350/
v0.17.9, built 2020-10-19

Initial Build • (Tiltfile)
WARNING: You are running Kind without a local image registry.
Tilt can use the local registry to speed up builds.
Instructions: https://github.com/tilt-dev/kind-local
Beginning Tiltfile execution
local: tilt version
Successfully loaded Tiltfile (5.262713173s)
Traceback (most recent call last):
  /root/Tiltfile:5:1: in <toplevel>
Error: cannot load ext://min_k8s_version: /root/tilt_modules/min_k8s_version/Tiltfile:31:24: undefined: s

```

My tilt file has the following details, and possibly where it failed. 

```
load('ext://min_tilt_version', 'min_tilt_version')
min_tilt_version('0.17.8')

# We require at minimum CRD support, so need at least Kubernetes v1.16
load('ext://min_k8s_version', 'min_k8s_version')
min_k8s_version('1.16')

```

changes:
A minor change is done to modify it to the correct name. 

