### PR TITLE
restart_process: fix restart_process for images that don't have sh or touch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 */test/.helm
 */test/.git-sources
 */test/.tilt-cache
+*/test/.build

--- a/restart_process/Dockerfile
+++ b/restart_process/Dockerfile
@@ -7,9 +7,11 @@ RUN git clone https://github.com/eradman/entr.git /entr
 WORKDIR /entr
 RUN git checkout c564e6bdca1dfe2177d1224363cad734158863ad
 RUN ./configure; CFLAGS="-static" make install
+RUN touch /.restart-proc
 
 FROM scratch
 
 COPY --from=0  /usr/local/bin/entr /
+COPY --from=0 /.restart-proc /.restart-proc
 
 ADD tilt-restart-wrapper /

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -27,11 +27,11 @@ def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, *
     # declare a new docker build that adds a static binary of tilt-restart-wrapper
     # (which makes use of `entr` to watch files and restart processes) to the user's image
     df = '''
-    FROM tiltdev/restart-helper:2020-10-16 as restart-helper
+    FROM tiltdev/restart-helper:2020-10-30 as restart-helper
 
     FROM {}
     USER root
-    RUN ["touch", "{}"]
+    COPY --from=restart-helper /.restart-proc {}
     COPY --from=restart-helper /tilt-restart-wrapper /
     COPY --from=restart-helper /entr /
     '''.format(base_ref, restart_file)
@@ -40,7 +40,10 @@ def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, *
     # `tilt-restart-wrapper` makes use of `entr` (https://github.com/eradman/entr/) to
     # re-execute $entrypoint whenever $restart_file changes
     if type(entrypoint) == type(""):
-        entrypoint_with_entr = ["/tilt-restart-wrapper", "--watch_file={}".format(restart_file), "sh", "-c", entrypoint]
+        if " " in entrypoint:
+            entrypoint_with_entr = ["/tilt-restart-wrapper", "--watch_file={}".format(restart_file), "sh", "-c", entrypoint]
+        else:
+            entrypoint_with_entr = ["/tilt-restart-wrapper", "--watch_file={}".format(restart_file), entrypoint]
     elif type(entrypoint) == type([]):
         entrypoint_with_entr = ["/tilt-restart-wrapper", "--watch_file={}".format(restart_file)] + entrypoint
     else:

--- a/restart_process/test/distroless.Tiltfile
+++ b/restart_process/test/distroless.Tiltfile
@@ -1,0 +1,21 @@
+load('../Tiltfile', 'docker_build_with_restart')
+
+k8s_yaml('distroless/deployment.yaml')
+k8s_resource('distroless', resource_deps=['build'], port_forwards='8081:8081')
+
+local_resource(
+  'build',
+  'mkdir -p .build && GOOS=linux GOARCH=amd64 go build -o .build/distroless ./distroless/main.go',
+  deps=['./distroless/main.go'])
+
+docker_build_with_restart(
+  'distroless-image',
+  './.build',
+  dockerfile_contents="""
+FROM gcr.io/distroless/base-debian10
+WORKDIR /app
+ADD distroless distroless
+ENTRYPOINT /app/distroless
+""",
+  entrypoint='/app/distroless',
+  live_update=[sync('./.build/distroless', '/app/distroless')])

--- a/restart_process/test/distroless/deployment.yaml
+++ b/restart_process/test/distroless/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: distroless
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: distroless
+  template:
+    metadata:
+      labels:
+        app: distroless
+    spec:
+      containers:
+      - name: distroless
+        image: distroless-image
+      readinessProbe:
+        httpGet: /
+        initialDelaySeconds: 1
+        periodSeconds: 1
+        port: 8081
+        

--- a/restart_process/test/distroless/main.go
+++ b/restart_process/test/distroless/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"html"
+	"log"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
+	})
+
+	log.Fatal(http.ListenAndServe(":8081", nil))
+}

--- a/restart_process/test/test-distroless.sh
+++ b/restart_process/test/test-distroless.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+cd $(dirname $0)
+
+tilt ci -f distroless.Tiltfile
+tilt down -f distroless.Tiltfile

--- a/restart_process/test/test.sh
+++ b/restart_process/test/test.sh
@@ -5,3 +5,4 @@ set -ex
 cd $(dirname $0)
 ./test-docker.sh
 ./test-custom.sh
+./test-distroless.sh


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/distroless:

8d4dd35e0da3a8bcee65ca7c5a271b6405241076 (2020-10-30 16:21:39 -0400)
restart_process: fix restart_process for images that don't have sh or touch

03b208c71f1979443737788a1bec2bb2a0b5520f (2020-10-30 15:46:49 -0400)
restart_process: add custom_build_with_restart

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics