### PR TITLE
Add extension for current_namespace

### DIFF
--- a/current_namespace/README.md
+++ b/current_namespace/README.md
@@ -1,0 +1,7 @@
+# Current Namespace
+
+The purpose of this extension is to easily fetch the active namespace within your kubernetes environment
+
+You can use this to quickly setup remote deployments using Tilt without having to hardcode any namespace within your tiltfile
+
+All you would have to do then would be to change your namespace using something like `kubens "your-namespace"` before running `tilt up`.

--- a/current_namespace/Tiltfile
+++ b/current_namespace/Tiltfile
@@ -1,0 +1,2 @@
+def current_namespace():
+  return str(local("kubectl config view --minify --output 'jsonpath={..namespace}'"))


### PR DESCRIPTION
This can be used to automate your Tiltfile dynamically by fetching the
current namespace and using it within your Tiltfile using string
templates.

All you would have to do then would be to change your namespace using
something like `kubens "your-namespace"` before running `tilt up`.

@victorwuky 
@shaimendel 