### PR TITLE
add current_namespace to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`cert_manager`](/cert_manager): Deploys cert-manager.
 - [`conftest`](/conftest): Use [Conftest](https://www.conftest.dev/) to test your configuration files.
 - [`coreos_prometheus`](/coreos_prometheus): Deploys Prometheus to a monitoring namespace, managed by the CoreOS Prometheus Operator and CRDs
+- [`current_namespace`](/current_namespace): Reads the default namespace from your kubectl config.
 - [`docker_build_sub`](/docker_build_sub): Specify extra Dockerfile directives in your Tiltfile beyond [`docker_build`](https://docs.tilt.dev/api.html#api.docker_build).
 - [`file_sync_only`](/file_sync_only): No-build, no-push, file sync-only development. Useful when you want to live-reload a single config file into an existing public image, like nginx.
 - [`git_resource`](/git_resource): Deploy a dockerfile from a remote repository -- or specify the path to a local checkout for local development.


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/namespace:

cacfca2a25b80fa22227cc8e65f39f23d3664af2 (2020-11-12 15:19:51 -0500)
add current_namespace to the readme

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics