### PR TITLE
fix kbuilder remove slash from resource name

### DIFF
--- a/kubebuilder/Tiltfile
+++ b/kubebuilder/Tiltfile
@@ -46,7 +46,7 @@ def kubebuilder(DOMAIN, GROUP, VERSION, KIND, IMG='controller:latest'):
     deps = ['controllers', 'main.go']
     deps.append('api')
     
-    local_resource('Watch/Compile', generate() + binary(), deps=deps, ignore=['*/*/zz_generated.deepcopy.go'])
+    local_resource('Watch&Compile', generate() + binary(), deps=deps, ignore=['*/*/zz_generated.deepcopy.go'])
     
     local_resource('Sample YAML', 'kubectl apply -f ./config/samples', deps=["./config/samples"], resource_deps=[DIRNAME + "-controller-manager"])
     


### PR DESCRIPTION
When clicking a resource with that has a slash in the name on the sidebar, I get e.g. `No match for /r/Watch/Compile`.