### PR TITLE
add support for tag references

### DIFF
--- a/git_resource/README.md
+++ b/git_resource/README.md
@@ -28,6 +28,7 @@ git_resource(resource_name, path_or_repo, dockerfile='Dockerfile', namespace='de
 * `path_or_repo` ( str ) – either the URL to the remote git repo, or the path to your local checkout.  
 If passing a repo url, a branch may be specified with a hash delimiter (i.e. `git@example.com/path/to/repo.git#myBranchNameHere`).  
 If no branch is specified, defaults to `master`
+To use a tag, prefix the tag name with `tags/` (i.e. `tags/v1.0.01`)
 * `dockerfile` ( str ) – the path to your dockerfile, relative to your git repository's root
 * `namespace` ( str ) – the namespace to deploy the built image to. This can be overridden within the `deployment_callback` function (see: [Custom Deployment YAML][2])
 * `resource_deps` ( List [ str ] ) – a list of resources on which this resource depends

--- a/git_resource/Tiltfile
+++ b/git_resource/Tiltfile
@@ -48,7 +48,10 @@ def git_checkout(repository_url, checkout_dir=None, unsafe_mode=False):
                     has_local_changes = int(str(local('cd %s && git status -sbuno | wc -l' % checkout_dir, quiet=True)).strip()) > 1  # result greater than 1 indicates local modifications are present
 
                 if unsafe_mode or not has_local_changes:
-                    local('cd %s && git fetch -a origin && git checkout -f origin/%s && git submodule update --init' % (checkout_dir, branch), quiet=True)
+                    if branch[:5] != 'tags/' and branch[:7] != 'origin/':
+                        branch = 'origin/%s' % branch
+
+                    local('cd %s && git fetch -a origin && git checkout -f %s && git submodule update --init' % (checkout_dir, branch), quiet=True)
                 else:
                     fail('git_checkout() failed: local modifications present and safe_mode is enabled')
 


### PR DESCRIPTION
This allows specifying a tag name as the resource branch. Tags are a special case, and things break if you try to do `git checkout origin/tagName` or `git checkout origin/tags/tagName`, so we must rewrite to `git checkout tags/tagName`

@nicks 
@victorwuky 