### PR TITLE
syncback: docstring, container support, option to sync all of src_dir

### DIFF
--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -3,7 +3,7 @@
 krsync_path = os.path.join(os.getcwd(), 'krsync.sh')
 
 
-def syncback(name, k8s_object, paths, src_dir, target_dir='.', namespace='', verbose=False):
+def syncback(name, k8s_object, src_dir, target_dir='.', paths=None, namespace='', verbose=False):
     """
     Create a local resource that will (via rsync) sync the specified files
     from the specified k8s object to the local filesystem.
@@ -12,19 +12,22 @@ def syncback(name, k8s_object, paths, src_dir, target_dir='.', namespace='', ver
     :param k8s_object (str): a Kubernetes object identifier (e.g. deploy/my-deploy, job/my-job, or a pod ID) that Tilt
            can use to select a pod. As per the behavior of `kubectl exec`, we will act on the first pod of the specified
            object, using the first container by default.
-    :param paths (List[str]): paths IN THE KUBERNETES CONTAINER to sync, relative to src_dir. May be files or dirs.
-           Note that these must not begin with `./`.
     :param src_dir (str): directory IN THE KUBERNETES CONTAINER to sync from. Any paths specified, if relative,
            should be relative to this dir.
     :param target_dir (str, optional): directory ON THE LOCAL FS to sync to. Defaults to '.'
+    :param paths (List[str], optional): paths IN THE KUBERNETES CONTAINER to sync, relative to src_dir. May be files or dirs.
+           Note that these must not begin with `./`. If no paths are provided, sync the entire src_dir.
     :param namespace (str, optiona): namespace of the desired k8s_object, if not `default`
     :param verbose (bool, optional): if true, print additional rsync information
     :return:
     """
 
-    # TODO: if you're rsync-savvy you might want to do the wildcarding manually--
-    #   give an option to turn off automatic +'***'
-    includes = ' '.join(['--include="{}***"'.format(p) for p in paths])
+    incl_excl = ''
+    if paths:
+        # TODO: if you're rsync-savvy you might want to do the wildcarding manually--
+        #   give an option to turn off automatic +'***'
+        includes = ' '.join(['--include="{}***"'.format(p) for p in paths])
+        incl_excl = '{} --exclude="*"'.format(includes)
 
     if not src_dir.endswith('/'):
         fail('src_dir must be a directory and have a trailing slash')
@@ -37,8 +40,8 @@ def syncback(name, k8s_object, paths, src_dir, target_dir='.', namespace='', ver
     if verbose:
         flags = '-aOvvi'
 
-    local_resource(name, '{krsync} {obj} {flags} --progress --stats --delete -T=/tmp/rsync.tilt {includes} --exclude="*" {remote}:{src} {target}'.
-                   format(krsync=krsync_path, obj=k8s_object, flags=flags, includes=includes,
+    local_resource(name, '{krsync} {obj} {flags} --progress --stats --delete -T=/tmp/rsync.tilt {include_exclude} {remote}:{src} {target}'.
+                   format(krsync=krsync_path, obj=k8s_object, flags=flags, include_exclude=incl_excl,
                           remote=remote_name, src=src_dir, target=target_dir),
                trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
 

--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -4,11 +4,23 @@ krsync_path = os.path.join(os.getcwd(), 'krsync.sh')
 
 
 def syncback(name, k8s_object, paths, src_dir, target_dir='.', namespace='', verbose=False):
-    # name (str) = resource name
-    # k8s_object (str) = thing to exec on (pod/foo, deployment/bar, etc)
-    # paths (List[str]) = paths ON CONTAINER to sync. May be files or dirs. May be absolute, or relative to src_dir
-    # src_dir = dir ON CONTAINER that paths are relative to
-    # target_dir (str) = dir on local FS to copy files back to (maybe abs or relative to Tiltfile)
+    """
+    Create a local resource that will (via rsync) sync the specified files
+    from the specified k8s object to the local filesystem.
+
+    :param name (str): name of the created local resource
+    :param k8s_object (str): a Kubernetes object identifier (e.g. deploy/my-deploy, job/my-job, or a pod ID) that Tilt
+           can use to select a pod. As per the behavior of `kubectl exec`, we will act on the first pod of the specified
+           object, using the first container by default.
+    :param paths (List[str]): paths IN THE KUBERNETES CONTAINER to sync, relative to src_dir. May be files or dirs.
+           Note that these must not begin with `./`.
+    :param src_dir (str): directory IN THE KUBERNETES CONTAINER to sync from. Any paths specified, if relative,
+           should be relative to this dir.
+    :param target_dir (str, optional): directory ON THE LOCAL FS to sync to. Defaults to '.'
+    :param namespace (str, optiona): namespace of the desired k8s_object, if not `default`
+    :param verbose (bool, optional): if true, print additional rsync information
+    :return:
+    """
 
     # TODO: if you're rsync-savvy you might want to do the wildcarding manually--
     #   give an option to turn off automatic +'***'

--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -3,12 +3,12 @@
 krsync_path = os.path.join(os.getcwd(), 'krsync.sh')
 
 
-def syncback(name, k8s_object, src_dir, target_dir='.', paths=None, namespace='', verbose=False):
+def syncback(name, k8s_object, src_dir, target_dir='.', paths=None, container='', namespace='', verbose=False):
     """
     Create a local resource that will (via rsync) sync the specified files
     from the specified k8s object to the local filesystem.
 
-    :param name (str): name of the created local resource
+    :param name (str): name of the created local resource.
     :param k8s_object (str): a Kubernetes object identifier (e.g. deploy/my-deploy, job/my-job, or a pod ID) that Tilt
            can use to select a pod. As per the behavior of `kubectl exec`, we will act on the first pod of the specified
            object, using the first container by default.
@@ -17,8 +17,9 @@ def syncback(name, k8s_object, src_dir, target_dir='.', paths=None, namespace=''
     :param target_dir (str, optional): directory ON THE LOCAL FS to sync to. Defaults to '.'
     :param paths (List[str], optional): paths IN THE KUBERNETES CONTAINER to sync, relative to src_dir. May be files or dirs.
            Note that these must not begin with `./`. If no paths are provided, sync the entire src_dir.
-    :param namespace (str, optiona): namespace of the desired k8s_object, if not `default`
-    :param verbose (bool, optional): if true, print additional rsync information
+    :param container (str, optiona): name of the container to sync from (by default, the first container)
+    :param namespace (str, optiona): namespace of the desired k8s_object, if not `default`.
+    :param verbose (bool, optional): if true, print additional rsync information.
     :return:
     """
 
@@ -35,6 +36,11 @@ def syncback(name, k8s_object, src_dir, target_dir='.', paths=None, namespace=''
     remote_name = 'dummy'
     if namespace:
         remote_name = 'dummy@{}'.format(namespace)
+
+    # instead of wrestling with passing optional args to krsync.sh that do not then
+    # get passed to rsync, just bundle container flag with k8s object specifier
+    if container:
+        k8s_object = '"{obj} -c {container}"'.format(obj=k8s_object, container=container)
 
     flags = '-aOv'
     if verbose:

--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -3,28 +3,32 @@
 krsync_path = os.path.join(os.getcwd(), 'krsync.sh')
 
 
-def syncback(name, k8s_object, paths, src_dir, target_dir='.', namespace=''):
+def syncback(name, k8s_object, paths, src_dir, target_dir='.', namespace='', verbose=False):
     # name (str) = resource name
     # k8s_object (str) = thing to exec on (pod/foo, deployment/bar, etc)
     # paths (List[str]) = paths ON CONTAINER to sync. May be files or dirs. May be absolute, or relative to src_dir
     # src_dir = dir ON CONTAINER that paths are relative to
     # target_dir (str) = dir on local FS to copy files back to (maybe abs or relative to Tiltfile)
 
-    if not src_dir.endswith('/'):
-        fail('src_dir must be a directory and have a trailing slash')
-
     # TODO: if you're rsync-savvy you might want to do the wildcarding manually--
     #   give an option to turn off automatic +'***'
     includes = ' '.join(['--include="{}***"'.format(p) for p in paths])
 
+    if not src_dir.endswith('/'):
+        fail('src_dir must be a directory and have a trailing slash')
+
     remote_name = 'dummy'
     if namespace:
         remote_name = 'dummy@{}'.format(namespace)
-    local_resource(name, '{krsync} {obj} -avO --progress --stats --delete -T=/tmp/rsync.tilt {includes} --exclude="*" {remote}:{src} {target}'.
-                   format(krsync=krsync_path, obj=k8s_object, includes=includes, remote=remote_name, src=src_dir, target=target_dir),
+
+    flags = '-aOv'
+    if verbose:
+        flags = '-aOvvi'
+
+    local_resource(name, '{krsync} {obj} {flags} --progress --stats --delete -T=/tmp/rsync.tilt {includes} --exclude="*" {remote}:{src} {target}'.
+                   format(krsync=krsync_path, obj=k8s_object, flags=flags, includes=includes,
+                          remote=remote_name, src=src_dir, target=target_dir),
                trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
 
-    # TODO: more verbosity option
     # TODO: not necessarily manual/can link up to a resource as a dep
-    # TODO: namespace support (i think we pass to krsync as my-deploy@my-namespace)
 


### PR DESCRIPTION
In this PR:
* docstrings (will also drop these into the readme, along with usage instructions)
* container support (`container` arg lets you specify container on the pod to act on)
* option to sync all of sync_dir instead of specifying individual paths