### PR TITLE
syncback: default excludes, can pass excludes

### DIFF
--- a/syncback/README.md
+++ b/syncback/README.md
@@ -26,37 +26,42 @@ For every syncback resource you want to create, invoke `syncback` with the follo
 
 * **name (str)**: name of the created local resource
 * **k8s_object (str)**: a Kubernetes object identifier (e.g. `deploy/my-deploy`, `job/my-job`, or a pod ID) that Tilt can use to select a pod. As per the behavior of `kubectl exec`, we will act on the first pod of the specified object, using the first container by default
+* **paths (List[str])**: paths *in the remote container* to sync, relative to `src_dir`. May be files or directories. Note that these must not begin with `./`. Pass an empty list to sync all of src_dir. THIS OPTION RISKS WIPING OUT FILES LOCALLY if the files exist at `target_dir` but not in the container. Tilt will protect some files automatically, but you will probably want to use the `ignores` parameter to explicitly protect other files that exist locally but not on the container.
 * **src_dir (str)**: directory *in the remote container* to sync from. Any `paths`, if specified, should be relative to this dir. This path *must* be a directory and must contain a trailing slash (e.g. `/app/` is acceptable; `/app` is not)
 
 You may also pass the following optional parameters:
-* **paths (List[str], optional)**: paths *in the remote container* to sync, relative to `src_dir`. May be files or directories. Note that these must not begin with `./`. If no paths are provided, we sync the entire `src_dir`
+* **ignore (List[str], optional)**: files to ignore when syncing (relative to src_dir).
 * **target_dir (str, optional)**: directory *on the local filesystem* to sync to. Defaults to `'.'`
-* **container (str, optiona)**: name of the container to sync from (by default, the first container)
+* **container (str, optional)**: name of the container to sync from (by default, the first container)
 * **namespace (str, optiona)**: namespace of the desired `k8s_object`, if not `default`.
 * **verbose (bool, optional)**: if true, print additional rsync information.
 
-### Example invocations:
-1. Create a local resource called "syncback-js" which connects to the first pod of "deploy/frontend" (and the default container) and syncs "/app/package.json" and "/app/yarn.lock" to local directory "./frontend".
+### Example invocations
+1. Create a local resource called "syncback-js" which connects to the first pod of "deploy/frontend" (and the default container) and syncs "/app/package.json" and "/app/yarn.lock" to local directory "./frontend":
     ```python
-    syncback('syncback-js', 'deploy/frontend', '/app/',
+    syncback('syncback-js', 'deploy/frontend',
+             ['package.json', 'yarn.lock'], '/app/',
              target_dir='./frontend',
-             paths=['package.json', 'yarn.lock']
     )
     ```
 
-2. Create a local resource called "syncback-portal" which connects to the first pod of "deploy/portal-app" (to container "app") in namespace $(whoami), and syncs the entire contents of "src/node_modules" to local directory "./portal/node_modules".
+2. Create a local resource called "syncback-portal" which connects to the first pod of "deploy/portal-app" (to container "app") in namespace $(whoami), and syncs the entire contents of "src/node_modules" to local directory "./portal/node_modules":
     ```python
     ns = str(local('whoami')).strip()
-    syncback('syncback-portal', 'deploy/portal-app', '/src/node_modules/',
+    syncback('syncback-portal', 'deploy/portal-app',
+             [], '/src/node_modules/',
              target_dir='./portal/node_modules',
              container='app',
              namespace=ns
     )
     ```
 
-3. Create a local resource called "syncback-data" which connects to the first pod of "job/data-cron" syncs the contents of "/data" to "."
+3. Create a local resource called "syncback-data" which connects to the first pod of "job/data-cron" syncs the contents of "/data" to the local cwd. Protect several files ("k8s.yaml", "config.json") that exist locally but not in the container (otherwise they would be deleted locally on sync):
     ```python
-    syncback('syncback-data', 'job/data-cron', '/data/')
+    syncback('syncback-data', 'job/data-cron',
+             [], '/data/',
+             ignore=['k8s.yaml', 'config.json']
+   )
     ```
 
 You can create as many syncback resources as you like; you'll need at minimum one syncback resource for every remote container you want to copy from, but you might choose to have different syncback resources for different sets of files, e.g. one to copy back `node_modules` and one to copy back your `data/` directory.

--- a/syncback/README.md
+++ b/syncback/README.md
@@ -26,11 +26,12 @@ For every syncback resource you want to create, invoke `syncback` with the follo
 
 * **name (str)**: name of the created local resource
 * **k8s_object (str)**: a Kubernetes object identifier (e.g. `deploy/my-deploy`, `job/my-job`, or a pod ID) that Tilt can use to select a pod. As per the behavior of `kubectl exec`, we will act on the first pod of the specified object, using the first container by default
-* **paths (List[str])**: paths *in the remote container* to sync, relative to `src_dir`. May be files or directories. Note that these must not begin with `./`. Pass an empty list to sync all of src_dir. THIS OPTION RISKS WIPING OUT FILES LOCALLY if the files exist at `target_dir` but not in the container. Tilt will protect some files automatically, but you will probably want to use the `ignores` parameter to explicitly protect other files that exist locally but not on the container.
 * **src_dir (str)**: directory *in the remote container* to sync from. Any `paths`, if specified, should be relative to this dir. This path *must* be a directory and must contain a trailing slash (e.g. `/app/` is acceptable; `/app` is not)
 
 You may also pass the following optional parameters:
 * **ignore (List[str], optional)**: files to ignore when syncing (relative to src_dir).
+* **delete (bool, optional)**: run `rsync` with the `--delete` flag, i.e. delete files locally if not present in the container. By default, False. *This option risks wiping out files* that exist locally but not in the container. Tilt will protect some files automatically, but we recommend syncing specific paths (via `paths`) and/or using the `ignore` parameter to explicitly protect local files from deletion.
+* **paths (List[str])**: paths *in the remote container* to sync, relative to `src_dir`. May be files or directories. Note that these must not begin with `./` or `/`. If this arg is not passed, sync all of src_dir.
 * **target_dir (str, optional)**: directory *on the local filesystem* to sync to. Defaults to `'.'`
 * **container (str, optional)**: name of the container to sync from (by default, the first container)
 * **namespace (str, optiona)**: namespace of the desired `k8s_object`, if not `default`.

--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -63,7 +63,7 @@ def syncback(name, k8s_object, src_dir, ignore=None, delete=False, paths=None, t
         # Sync the entire src_dir. Danger, Will Robinson! Exclude some stuff
         # that may exist locally but not in your container so it
         # doesn't get wiped out locally on your first sync
-        to_exclude.extend(DEFAULT_EXCLUDES)
+        to_exclude = DEFAULT_EXCLUDES + to_exclude
 
     excludes = ' '.join(['--exclude="{}***"'.format(ex) for ex in to_exclude])
     incl_excl = '{} {}'.format(excludes, incl_excl)

--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -9,9 +9,9 @@ verify_rsync_path = os.path.join(os.getcwd(), 'verify_rsync.sh')
 print('-- syncback extension checking for local rsync --')
 local('{} {}'.format(verify_rsync_path, MIN_LOCAL_RSYNC_VERSION))
 
-DEFAULT_IGNORES = ['.git', '.gitignore', '.dockerignore', 'Dockerfile', '.tiltignore', 'Tiltfile', 'tilt_modules']
+DEFAULT_EXCLUDES = ['.git', '.gitignore', '.dockerignore', 'Dockerfile', '.tiltignore', 'Tiltfile', 'tilt_modules']
 
-def syncback(name, k8s_object, paths, src_dir, ignore=None, target_dir='.', container='', namespace='', verbose=False):
+def syncback(name, k8s_object, paths, src_dir, delete=False, ignore=None, target_dir='.', container='', namespace='', verbose=False):
     """
     Create a local resource that will (via rsync) sync the specified files
     from the specified k8s object to the local filesystem.
@@ -27,6 +27,8 @@ def syncback(name, k8s_object, paths, src_dir, ignore=None, target_dir='.', cont
            to explicitly protect other files that exist locally but not on the container.
     :param src_dir (str): directory IN THE KUBERNETES CONTAINER to sync from. Any paths specified, if relative,
            should be relative to this dir.
+    :param delete (bool, optional): run rsync with the --delete flag, i.e. delete files locally if not present in
+           the container. By default, False.
     :param ignore (List[str], optional): files to ignore when syncing (relative to src_dir).
     :param target_dir (str, optional): directory ON THE LOCAL FS to sync to. Defaults to '.'
     :param container (str, optiona): name of the container to sync from (by default, the first container)
@@ -35,9 +37,23 @@ def syncback(name, k8s_object, paths, src_dir, ignore=None, target_dir='.', cont
     :return:
     """
 
+    # Verify inputs
+    if not src_dir.endswith('/'):
+        fail('src_dir must be a directory and have a trailing slash (because of rsync syntax rules)')
+
+    if paths:
+        for p in paths:
+            if p.startswith('./'):
+                fail('Found illegal path "{}": paths may not begin with ./ (because of rsync syntax rules)'.format(p))
+            if p.startswith('/'):
+                fail('Found illegal path "{}": paths may not begin with / and must be relative to src_dir (because of rsync syntax rules)'.format(p))
+
+    # Construct include/exclude rules
     incl_excl = ''
-    if ignore == None:
-        ignore = []
+
+    to_exclude = ignore
+    if not ignore:
+        to_exclude = []
 
     if paths:
         # TODO: if you're rsync-savvy you might want to do the wildcarding manually--
@@ -45,17 +61,18 @@ def syncback(name, k8s_object, paths, src_dir, ignore=None, target_dir='.', cont
         includes = ' '.join(['--include="{}***"'.format(p) for p in paths])
         incl_excl = '{} --exclude="*"'.format(includes)
     else:
-        # Sync the entire src_dir. Danger, Will Robinson! Ignore some stuff
-        # that probably exists locally but not in your container so it
+        # Sync the entire src_dir. Danger, Will Robinson! Exclude some stuff
+        # that may exist locally but not in your container so it
         # doesn't get wiped out locally on your first sync
-        ignore.extend(DEFAULT_IGNORES)
+        to_exclude.extend(DEFAULT_EXCLUDES)
 
-    excludes = ' '.join(['--exclude="{}***"'.format(ig) for ig in ignore])
+    excludes = ' '.join(['--exclude="{}***"'.format(ex) for ex in to_exclude])
     incl_excl = '{} {}'.format(excludes, incl_excl)
 
-    if not src_dir.endswith('/'):
-        fail('src_dir must be a directory and have a trailing slash')
-
+    # construct remote name (maybe with namespace)
+    # (when we pass `dummy@namespace` to krsync, it gets parsed and then passed to
+    # `rsync --rsh` as two args, `dummy` and `namespace`. We grab the latter to use,
+    # and ignore the former in favor of k8s_object info we stashed in an env variable
     remote_name = 'dummy'
     if namespace:
         remote_name = 'dummy@{}'.format(namespace)
@@ -69,9 +86,12 @@ def syncback(name, k8s_object, paths, src_dir, ignore=None, target_dir='.', cont
     if verbose:
         flags = '-aOvvi'
 
-    local_resource(name, '{krsync} {obj} {flags} --progress --stats --delete -T=/tmp/rsync.tilt {include_exclude} {remote}:{src} {target}'.
-                   format(krsync=krsync_path, obj=k8s_object, flags=flags, include_exclude=incl_excl,
-                          remote=remote_name, src=src_dir, target=target_dir),
+    delete_flag = ''
+    if delete:
+        delete_flag = '--delete'
+    local_resource(name, '{krsync} {obj} {flags} --progress --stats {delete} -T=/tmp/rsync.tilt {include_exclude} {remote}:{src} {target}'.
+                   format(krsync=krsync_path, obj=k8s_object, flags=flags, delete=delete_flag,
+                          include_exclude=incl_excl, remote=remote_name, src=src_dir, target=target_dir),
                trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
 
     # TODO: not necessarily manual/can link up to a resource as a dep

--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -11,7 +11,7 @@ local('{} {}'.format(verify_rsync_path, MIN_LOCAL_RSYNC_VERSION))
 
 DEFAULT_EXCLUDES = ['.git', '.gitignore', '.dockerignore', 'Dockerfile', '.tiltignore', 'Tiltfile', 'tilt_modules']
 
-def syncback(name, k8s_object, paths, src_dir, delete=False, ignore=None, target_dir='.', container='', namespace='', verbose=False):
+def syncback(name, k8s_object, src_dir, ignore=None, delete=False, paths=None, target_dir='.', container='', namespace='', verbose=False):
     """
     Create a local resource that will (via rsync) sync the specified files
     from the specified k8s object to the local filesystem.
@@ -20,16 +20,15 @@ def syncback(name, k8s_object, paths, src_dir, delete=False, ignore=None, target
     :param k8s_object (str): a Kubernetes object identifier (e.g. deploy/my-deploy, job/my-job, or a pod ID) that Tilt
            can use to select a pod. As per the behavior of `kubectl exec`, we will act on the first pod of the specified
            object, using the first container by default.
-    :param paths (List[str]): paths IN THE KUBERNETES CONTAINER to sync, relative to src_dir. May be files or dirs.
-           Note that these must not begin with `./`. Pass an empty list to sync all of src_dir.
-           THIS OPTION RISKS WIPING OUT FILES LOCALLY if the files exist at `target_dir` but not in the container.
-           Tilt will protect some files automatically, but you will probably want to use the `ignores` parameter
-           to explicitly protect other files that exist locally but not on the container.
     :param src_dir (str): directory IN THE KUBERNETES CONTAINER to sync from. Any paths specified, if relative,
            should be relative to this dir.
-    :param delete (bool, optional): run rsync with the --delete flag, i.e. delete files locally if not present in
-           the container. By default, False.
     :param ignore (List[str], optional): files to ignore when syncing (relative to src_dir).
+    :param delete (bool, optional): run rsync with the --delete flag, i.e. delete files locally if not present in
+           the container. By default, False. THIS OPTION RISKS WIPING OUT FILES that exist locally but not in the
+           container. Tilt will protect some files automatically, but we recommend syncing specific paths (via `paths`
+           and/or using the `ignore` parameter to explicitly protect other files that exist locally but not on the container.
+    :param paths (List[str], optional): paths IN THE KUBERNETES CONTAINER to sync, relative to src_dir. May be files or dirs.
+           Note that these must not begin with `./`. If this arg is not passed, sync all of src_dir.
     :param target_dir (str, optional): directory ON THE LOCAL FS to sync to. Defaults to '.'
     :param container (str, optiona): name of the container to sync from (by default, the first container)
     :param namespace (str, optiona): namespace of the desired k8s_object, if not `default`.

--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -9,7 +9,9 @@ verify_rsync_path = os.path.join(os.getcwd(), 'verify_rsync.sh')
 print('-- syncback extension checking for local rsync --')
 local('{} {}'.format(verify_rsync_path, MIN_LOCAL_RSYNC_VERSION))
 
-def syncback(name, k8s_object, src_dir, paths=None, target_dir='.', container='', namespace='', verbose=False):
+DEFAULT_IGNORES = ['.git', '.gitignore', '.dockerignore', 'Dockerfile', '.tiltignore', 'Tiltfile', 'tilt_modules']
+
+def syncback(name, k8s_object, paths, src_dir, ignore=None, target_dir='.', container='', namespace='', verbose=False):
     """
     Create a local resource that will (via rsync) sync the specified files
     from the specified k8s object to the local filesystem.
@@ -18,10 +20,14 @@ def syncback(name, k8s_object, src_dir, paths=None, target_dir='.', container=''
     :param k8s_object (str): a Kubernetes object identifier (e.g. deploy/my-deploy, job/my-job, or a pod ID) that Tilt
            can use to select a pod. As per the behavior of `kubectl exec`, we will act on the first pod of the specified
            object, using the first container by default.
+    :param paths (List[str]): paths IN THE KUBERNETES CONTAINER to sync, relative to src_dir. May be files or dirs.
+           Note that these must not begin with `./`. Pass an empty list to sync all of src_dir.
+           THIS OPTION RISKS WIPING OUT FILES LOCALLY if the files exist at `target_dir` but not in the container.
+           Tilt will protect some files automatically, but you will probably want to use the `ignores` parameter
+           to explicitly protect other files that exist locally but not on the container.
     :param src_dir (str): directory IN THE KUBERNETES CONTAINER to sync from. Any paths specified, if relative,
            should be relative to this dir.
-    :param paths (List[str], optional): paths IN THE KUBERNETES CONTAINER to sync, relative to src_dir. May be files or dirs.
-           Note that these must not begin with `./`. If no paths are provided, sync the entire src_dir.
+    :param ignore (List[str], optional): files to ignore when syncing (relative to src_dir).
     :param target_dir (str, optional): directory ON THE LOCAL FS to sync to. Defaults to '.'
     :param container (str, optiona): name of the container to sync from (by default, the first container)
     :param namespace (str, optiona): namespace of the desired k8s_object, if not `default`.
@@ -30,11 +36,22 @@ def syncback(name, k8s_object, src_dir, paths=None, target_dir='.', container=''
     """
 
     incl_excl = ''
+    if ignore == None:
+        ignore = []
+
     if paths:
         # TODO: if you're rsync-savvy you might want to do the wildcarding manually--
         #   give an option to turn off automatic +'***'
         includes = ' '.join(['--include="{}***"'.format(p) for p in paths])
         incl_excl = '{} --exclude="*"'.format(includes)
+    else:
+        # Sync the entire src_dir. Danger, Will Robinson! Ignore some stuff
+        # that probably exists locally but not in your container so it
+        # doesn't get wiped out locally on your first sync
+        ignore.extend(DEFAULT_IGNORES)
+
+    excludes = ' '.join(['--exclude="{}***"'.format(ig) for ig in ignore])
+    incl_excl = '{} {}'.format(excludes, incl_excl)
 
     if not src_dir.endswith('/'):
         fail('src_dir must be a directory and have a trailing slash')


### PR DESCRIPTION
Flagged by @djcp (🙏🏻):
> One issue with this: if you set paths to include the entire repo (so empty), this'll remove your `.git/` directory in the host because of the `--delete` directive and how it interacts with default ignores.  Probably an explicit additional `excludes` option could fix this.

Not convinced that this API (`paths` is NON-optional, pass `[]` to watch entire dir) is the right API, but I wanted to make it a little harder to watch the entire dir/make sure it's a deliberate choice when it happens, b/c it's a dangerous option and you need to set your `ignore` values correctly or you risk blowing away data. Not quite sure how to do this tho, thoughts?

(Also, called the parameter `ignore` to match `docker_build` params, but happy for it to be whatever--`ignores`? `excludes`?)