### PR TITLE
helm_remote fix endless chart update loop + security improvements

### DIFF
--- a/helm_remote/README.md
+++ b/helm_remote/README.md
@@ -6,9 +6,6 @@ Install a remotely hosted Helm chart in a way that it will be properly uninstall
 
 ## Usage
 
-Because tilt doesn't have a way to dynamically ignore files, you'll need to add `.helm` to your project's `.tiltignore`
-file in order to prevent recursive re-processing of the main Tiltfile when the helm cache changes/updates.
-
 #### Install a Remote Chart
 
 ```py

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -40,7 +40,8 @@ metadata:
 def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], set=[], namespace='', version='', username='', password='', allow_duplicates=False, create_namespace=False):
     # ======== Helper methods
     def get_local_repo(repo_name, repo_url):
-        added_helm_repos = decode_yaml(local('helm repo list --output yaml'))
+        # if no repos are present, helm exit code is >0 and stderr output buffered
+        added_helm_repos = decode_yaml(local('helm repo list --output yaml 2>/dev/null || true', command_bat='helm repo list --output yaml 2>&1 || ver>nul'))
         repo = [item for item in added_helm_repos if item['name'] == chart and item['url'] == repo_url]
 
         return repo[0] if len(repo) > 0 else None

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -78,6 +78,24 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
     if version == '':
         version = 'latest'
 
+    # ======== Validate before we start trusting chart/repo names
+
+    # Based on helm chart conventions, and the fact we don't want anyone traversing directories
+    # validate is to essentially ensure there's no special characters aside from '-' being used
+    # https://helm.sh/docs/chart_best_practices/conventions/#chart-names
+
+    if chart.replace('-', '').isalnum() == False or chart == chart.replace('.', ''):
+        # https://helm.sh/docs/chart_best_practices/conventions/#chart-names
+        fail('Chart name is not validate')
+
+    if repo_name != chart and (repo_name.replace('-', '').isalnum() == False or repo_name == repo_name.replace('.', '')):
+        # https://helm.sh/docs/chart_best_practices/conventions/#chart-names
+        fail('Repo name is not validate')
+
+    if version != 'latest' and version != version.replace('/', '').replace('\\', ''):
+        fail('Version cannot contain a forward slash')
+
+
     # ======== Determine state of existing helm repo
     if repo_url != '':
         local_helm_repo = get_local_repo(repo_name, repo_url)

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -38,6 +38,36 @@ metadata:
 
 
 def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], set=[], namespace='', version='', username='', password='', allow_duplicates=False, create_namespace=False):
+    # ======== Helper methods
+    def get_local_repo(repo_name, repo_url):
+        added_helm_repos = decode_yaml(local('helm repo list --output yaml'))
+        repo = [item for item in added_helm_repos if item['name'] == chart and item['url'] == repo_url]
+
+        return repo[0] if len(repo) > 0 else None
+
+    # Command string builder with common argument logic
+    def build_helm_command(command, auth=None, version=None):
+        command = 'helm ' + command
+
+        if auth != None:
+            username, password = auth
+            if username != '':
+                command += ' --username %s' % shlex.quote(username)
+            if password != '':
+                command += ' --password %s' % shlex.quote(password)
+
+        if version != None and version != 'latest':
+            command += ' --version %s' % shlex.quote(version)
+
+        return command
+
+    def fetch_chart_details(chart, repo_name, auth, version):
+        command = build_helm_command('search repo %s/%s --output yaml' % (shlex.quote(repo_name), shlex.quote(chart)), auth, version)
+        results = decode_yaml(local(command))
+
+        return results[0] if len(results) > 0 else None
+
+
     # ======== Condition Incoming Arguments
     if repo_name == '':
         repo_name = chart
@@ -45,24 +75,22 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
         release_name = chart
     if namespace == '':
         namespace = 'default'
+    if version == '':
+        version = 'latest'
+
+    # ======== Determine state of existing helm repo
     if repo_url != '':
-        repo_add_command = 'helm repo add %s %s' % (repo_name, repo_url)
+        local_helm_repo = get_local_repo(repo_name, repo_url)
+
+        if (local_helm_repo == None):
+            # Unaware of repo, add it 
+            repo_command = 'repo add %s %s' % (shlex.quote(repo_name), shlex.quote(repo_url))
+        else:
+            # Helm is already aware of the chart, update repo (unfortunately you cannot specify a single repo)
+            repo_command = 'repo update'
 
         # Add authentification for adding the repository if credentials are provided
-        if username != '':
-            repo_add_command += ' --username %s' % username
-        if password != '':
-            repo_add_command += ' --password %s' % password
-
-
-        # Retry the add command with --force-update if it fails the first time.
-        # This is dumb, but it's the most portable way I can think of to fix
-        # https://github.com/tilt-dev/tilt-extensions/issues/83
-        # without going down the rabbit hole of having a bunch of 'if' blocks
-        # for different Helm versions.
-        repo_add_command_with_retry = '%s || %s --force-update' % (repo_add_command, repo_add_command)
-
-        local(repo_add_command_with_retry)
+        local(build_helm_command(repo_command, (username, password)))
 
     # ======== Create Namespace
     if create_namespace and namespace != '' and namespace != 'default':
@@ -71,29 +99,36 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
 
     # ======== Initialize
     # -------- targets
-    pull_target = os.path.join(helm_remote_cache_dir, repo_name)
-    if version != '':
-        pull_target = os.path.join(pull_target, version)
-    else:
-        pull_target = os.path.join(pull_target, 'latest')
-
+    pull_target = os.path.join(helm_remote_cache_dir, repo_name, version)
     chart_target = os.path.join(pull_target, chart)
 
-    # -------- commands
-    pull_command = 'helm pull %s/%s --untar --destination %s' % (repo_name, chart, pull_target)
-    if version != '':
-        pull_command += ' --version %s' % version
-    if username != '':
-        pull_command += ' --username %s' % username
-    if password != '':
-        pull_command += ' --password %s' % password
+    cached_chart_exists = os.path.exists(chart_target)
 
-    # ======== Perform Installation
-    local('rm -rf %s' % chart_target,
-          command_bat='if exist %s ( rd /s /q %s )' % (chart_target, chart_target))
-    local(pull_command)
+    pull = True
 
-    install_crds(chart, chart_target)
+    if cached_chart_exists == True:
+        # Helm chart structure is concrete, we can trust this YAML file to exist
+        cached_chart_details = read_yaml(os.path.join(chart_target, 'Chart.yaml'))
+
+        # check if our local cached chart matches latest remote
+        remote_chart_details = fetch_chart_details(chart, repo_name, (username, password), version)
+        
+        # pull when version mismatch
+        pull = cached_chart_details['version'] != remote_chart_details['version']
+
+
+    if pull == True:
+        # -------- commands
+        pull_command = 'pull %s/%s --untar --destination %s' % (repo_name, chart, pull_target)
+
+        # ======== Perform Installation
+        if cached_chart_exists == True:
+            local('rm -rf %s' % chart_target,
+                  command_bat='if exist %s ( rd /s /q %s )' % (chart_target, chart_target))
+
+        local(build_helm_command(pull_command, (username, password), version))
+
+        install_crds(chart, chart_target)
 
     # TODO: since neither `k8s_yaml()` nor `helm()` accept resource_deps,
     # sometimes the crds haven't yet finished installing before the below tries

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -42,7 +42,7 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
     def get_local_repo(repo_name, repo_url):
         # if no repos are present, helm exit code is >0 and stderr output buffered
         added_helm_repos = decode_yaml(local('helm repo list --output yaml 2>/dev/null || true', command_bat='helm repo list --output yaml 2>&1 || ver>nul'))
-        repo = [item for item in added_helm_repos if item['name'] == chart and item['url'] == repo_url] if added_helm_repos != None
+        repo = [item for item in added_helm_repos if item['name'] == chart and item['url'] == repo_url] if added_helm_repos != None else []
 
         return repo[0] if len(repo) > 0 else None
 

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -148,7 +148,7 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
 
         local(build_helm_command(pull_command, (username, password), version))
 
-        install_crds(chart, chart_target)
+    install_crds(chart, chart_target)
 
     # TODO: since neither `k8s_yaml()` nor `helm()` accept resource_deps,
     # sometimes the crds haven't yet finished installing before the below tries

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -82,13 +82,14 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
 
     # Based on helm chart conventions, and the fact we don't want anyone traversing directories
     # validate is to essentially ensure there's no special characters aside from '-' being used
+    # str.isalnum accepts dots, which is only dangerous when slashes are allowed 
     # https://helm.sh/docs/chart_best_practices/conventions/#chart-names
 
-    if chart.replace('-', '').isalnum() == False or chart == chart.replace('.', ''):
+    if chart.replace('-', '').isalnum() == False or chart != chart.replace('.', ''):
         # https://helm.sh/docs/chart_best_practices/conventions/#chart-names
         fail('Chart name is not validate')
 
-    if repo_name != chart and (repo_name.replace('-', '').isalnum() == False or repo_name == repo_name.replace('.', '')):
+    if repo_name != chart and repo_name.replace('-', '').isalnum() == False or repo_name != repo_name.replace('.', ''):
         # https://helm.sh/docs/chart_best_practices/conventions/#chart-names
         fail('Repo name is not validate')
 

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -88,11 +88,11 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
 
     if chart.replace('-', '').isalnum() == False or chart != chart.replace('.', ''):
         # https://helm.sh/docs/chart_best_practices/conventions/#chart-names
-        fail('Chart name is not validate')
+        fail('Chart name is not valid')
 
     if repo_name != chart and repo_name.replace('-', '').isalnum() == False or repo_name != repo_name.replace('.', ''):
         # https://helm.sh/docs/chart_best_practices/conventions/#chart-names
-        fail('Repo name is not validate')
+        fail('Repo name is not valid')
 
     if version != 'latest' and version != version.replace('/', '').replace('\\', ''):
         fail('Version cannot contain a forward slash')
@@ -109,7 +109,7 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
             # Helm is already aware of the chart, update repo (unfortunately you cannot specify a single repo)
             repo_command = 'repo update'
 
-        # Add authentification for adding the repository if credentials are provided
+        # Add authentication for adding the repository if credentials are provided
         local(build_helm_command(repo_command, (username, password)))
 
     # ======== Create Namespace

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -42,7 +42,7 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
     def get_local_repo(repo_name, repo_url):
         # if no repos are present, helm exit code is >0 and stderr output buffered
         added_helm_repos = decode_yaml(local('helm repo list --output yaml 2>/dev/null || true', command_bat='helm repo list --output yaml 2>&1 || ver>nul'))
-        repo = [item for item in added_helm_repos if item['name'] == chart and item['url'] == repo_url]
+        repo = [item for item in added_helm_repos if item['name'] == chart and item['url'] == repo_url] if added_helm_repos != None
 
         return repo[0] if len(repo) > 0 else None
 


### PR DESCRIPTION
Refactored helm_remote Tiltfile to remove the pessimism, and only perform changes when required
This stops the endless looping issue without having to change your `.tiltiginore`
resolves (my reported) issue https://github.com/tilt-dev/tilt-extensions/issues/116 and contains other improvements

also noticed a few spots for improving security, namely avoiding directory traversal from arbitrary inputs, especially because `rm` is involved with this.
This prevents chart/repo names like `something/../../` or `something && cat /etc/passwd` from being entertained, and shell 

**Changes** (there's no breaking changes)
- Fixed the indefinite loop that was possible due to how remote helm charts were being handled 
- Chart will only be re-downloaded to filesystem (`helm pull`) when required
  - this is based on a version comparison between local cached (if existent) and remote chart version
- Repository update is done independently
- Improved security for many input arguments that derive from user input
   - Added validation and failure messages for unsuitable input values
- Removed the need for `--force-update` which divides users depending on their helm version
  - (helm repo update resolves that need)
- Reduced repeated code (ie. command argument parsing for auth/user)