### PR TITLE
Tidy up extension, add support for trigger modes and info only

### DIFF
--- a/snyk/README.md
+++ b/snyk/README.md
@@ -1,43 +1,59 @@
 # Use Snyk to test your configuration files
 
 Author: [Shai Mendel](https://github.com/shaimendel)
-* Additional contributor: [Jim Armstrong](https://github.com/jimcodified)
+* Additional contributors: 
+	[Jim Armstrong](https://github.com/jimcodified)
+	[Matt Jarvis](https://github.com/mattj-io)
 
 [Snyk](https://https://snyk.io/) is a product to help developers to continuously find and fix vulnerabilities in open source libraries, containers and Infrastructure as Code configurations.
 
+## Requirements
+
+* The `snyk` binary must be on your path. See https://support.snyk.io/hc/en-us/articles/360003812538-Install-the-Snyk-CLI for details on installing, and register for a free Snyk account at https://app.snyk.io/login
+
 ## Usage
 
-The `snyk` extension can be run like so:
+The extension takes a number of arguments:
+
+name: a name for the resource. Useful for labeling when running multiple tests. Defaults to 'snyk'
+target: path to the file/dir or container image name:tag to test
+test_type: one of 'oss', 'container', or 'iac' corresponding to the various Snyk CLI tests
+test_deps: automatically set for test types other than container, allows for setting an external file/dir dependency
+extra_opts: additional CLI options; appended to the snyk command. see `snyk --help` for usage.
+          - when using the container switch this is where to insert the '--file=path/to/Dockerfile' option
+trigger: trigger mode - auto or manual, defaults to manual
+mode: control Snyk exit code, info will always exit 0 - gate or info, defaults to gate
+
+The `snyk` extension can be run in a variety of different ways:
 
 ```python
+# Load the extension
 load('ext://snyk', 'snyk')
 
-docker_build('myimage:v1','.')
+# Scan Kubernetes YAML files - in this case manually triggered and in informational-only mode
+snyk('kubernetes.yaml', 'iac', 'snyk-iac-manual', mode='info')
 
-snyk('myimage:v1', 'container', 'snyk-cnr', 'example', '--file=Dockerfile')
-snyk('deployment.yaml', 'iac', 'snyk-iac')
+# Scan application code dependencies - in this case automatically on change and in gating mode
+snyk('.', 'oss', 'snyk-oss-auto', mode='gate', trigger='auto')
+
+# Manually scan Docker builds
+# Set mutable tags for the initial build, Tilt will re-tag with immutable during deploy
+custom_build('example-nodejs-image', 'docker build -t $EXPECTED_REF .', ['.'], tag='dev')
+# Run snyk manually against the mutable tag, in informational mode, and also scan a Dockerfile in the same directory
+snyk('example-nodejs-image:dev', 'container', 'snyk-cnr-manual', mode='info', extra_opts='--file=Dockerfile')
+
+# Automatically scan Docker builds
+# Extract the immutable tag on build and write to a file in the filesystem
+custom_build('example-nodejs-image', 'docker build -t $EXPECTED_REF . && echo $EXPECTED_REF > /tmp/ref.txt', ['.'])
+# Extract the tag from the file and strip any newlines
+def get_tag():
+    return str(read_file('/tmp/ref.txt')).rstrip('\n')    
+# Run snyk automatically in informational mode when the file containing the tag changes
+snyk(get_tag(), 'container', 'snyk-cnr-auto', test_deps='/tmp/ref.txt', mode='info', extra_opts='--file=Dockerfile', trigger='auto')
 
 k8s_yaml('kubernetes.yaml')
-k8s_resource('example',
-    port_forwards=8000,
-    resource_deps=['snyk'],
+k8s_resource('example-node.js',
+    port_forwards=8000
 )
 ```
 
-The function takes a number of arguments:
-
-* **path**: path to the file or container image name:tag to test
-* **test_type**: one of 'oss', 'container', or 'iac' corresponding to the various Snyk CLI tests
-* **name**: a name for the resource. useful for labeling when running multiple tests. Defaults to 'snyk'.
-* **k8s_dep**: used for test_type=='container' and sets Tilt re-test dependency. Ignored by other test types.
-* **extra_opts**: additional CLI options; appended to the snyk command. see `snyk --help` for CLI options.
-  * container: this is where to insert the 'file==path/to/Dockerfile' option
-  * ' --severity-threshold=[high|medium|low]' is another useful consideration
-
-## Requirements
-
-* The `snyk` binary must be on your path
-
-## Other notes
-
-The re-test is currently set to manual. The first tests will be run automatically when you `tilt up` but subsequent tests need to be started manually so you only run the Snyk tests  when you're ready.

--- a/snyk/Tiltfile
+++ b/snyk/Tiltfile
@@ -1,40 +1,57 @@
-def snyk(path, test_type, name='snyk', k8s_dep='', extra_opts=''):
+def snyk(target, test_type, name='snyk', test_deps='', extra_opts='', trigger='manual', mode='gate'):
     """
     Args:
       name: a name for the resource. useful for labeling when running multiple tests.
-      path: path to the file or container image name:tag to test
+      target: path to the file/dir or container image name:tag to test
       test_type: one of 'oss', 'container', or 'iac' corresponding to the various Snyk CLI tests
-      k8s_resource: used for container tests - sets the re-test dependency. ignored by other test types.
+      test_deps: automatically set for test types other than container, allows for setting an external file/dir dependency
       extra_opts: additional CLI options; appended to the snyk command. see `snyk --help` for usage.
-          - container: this is where to insert the 'file=path/to/Dockerfile' option
+          - container: this is where to insert the '--file=path/to/Dockerfile' option
+      trigger: trigger mode - auto or manual
+      mode: control Snyk exit code, info will always exit 0 - gate or info
     """
+
     if test_type == 'oss':
-        snyk_cmd = " ".join([
+        snyk_cmd = [
             "snyk test --all-projects",
-            path
-        ])
-        test_deps = [path]
+            target
+        ]
+        test_deps = [target]
     elif test_type == 'container':
-        snyk_cmd = " ".join([
+        snyk_cmd = [
             "snyk container test",
-            path
-        ])
-        test_deps = [k8s_dep]
+            target
+        ]
     elif test_type == 'iac':
-        snyk_cmd = " ".join([
+        snyk_cmd = [
             "snyk iac test",
-            path
-        ])
-        test_deps = [path]
+            target
+        ]
+        test_deps = [target]
     else:
         fail("Snyk test_type should be one of oss, container, or iac.")
 
     if (len(extra_opts) > 0):
-        snyk_cmd = " ".join([snyk_cmd, extra_opts])
+        snyk_cmd.append(extra_opts)
+
+    if mode == 'info':
+        snyk_cmd.append("|| true")
+
+    snyk_cmd = " ".join(snyk_cmd)
+
+    if trigger == 'manual':
+        trigger_string = TRIGGER_MODE_MANUAL
+        auto_bool = False
+    elif trigger == 'auto':
+        trigger_string = TRIGGER_MODE_AUTO
+        auto_bool = True
+    else:
+        fail("Snyk trigger should be one of manual or auto")
 
     local_resource(
         name,
         deps = test_deps,
         cmd = snyk_cmd,
-        trigger_mode=TRIGGER_MODE_MANUAL
+        auto_init = auto_bool,
+        trigger_mode = trigger_string
     )


### PR DESCRIPTION
Adds support for different trigger modes, and a switch to control the exit code for gating or information only. Tidy up arg names, update README