### PR TITLE
restart_process: optional trigger arg to only restart process when specified files change

### DIFF
--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -79,6 +79,7 @@ def docker_build_with_restart(ref: str, context: str,
     live_update: List[LiveUpdateStep],
     base_suffix: str = '-base',
     restart_file: str = '/.restart-proc',
+    trigger: Union[str, List[str]] = [],
     **kwargs
 ):
     """Args:
@@ -88,6 +89,8 @@ def docker_build_with_restart(ref: str, context: str,
       live_update: set of steps for updating a running container; as the parameter of the same name in docker_build
       base_suffix: suffix for naming the base image, applied as {ref}{base_suffix}
       restart_file: file that Tilt will update during a live_update to signal the entrypoint to rerun
+      trigger: (optional) list of local paths. If specified, the process will ONLY be restarted when there are changes
+               to the given file(s); as the parameter of the same name in the LiveUpdate `run` step.
       **kwargs: will be passed to the underlying `docker_build` call
     """
     
@@ -98,6 +101,7 @@ def custom_build_with_restart(ref: str, command: str, deps: List[str], entrypoin
     live_update: List[LiveUpdateStep],
     base_suffix: str = '-base',
     restart_file: str = '/.restart-proc',
+    trigger: Union[str, List[str]] = [],
     , **kwargs
 ):
     """
@@ -109,6 +113,8 @@ def custom_build_with_restart(ref: str, command: str, deps: List[str], entrypoin
       live_update: set of steps for updating a running container; as the parameter of the same name in custom_build
       base_suffix: suffix for naming the base image, applied as {ref}{base_suffix}
       restart_file: file that Tilt will update during a live_update to signal the entrypoint to rerun
+      trigger: (optional) list of local paths. If specified, the process will ONLY be restarted when there are changes
+               to the given file(s); as the parameter of the same name in the LiveUpdate `run` step.
       **kwargs: will be passed to the underlying `custom_build` call
     """
 ```

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -23,7 +23,10 @@ _CUSTOM_BUILD_KWARGS_BLACKLIST = [
 _ext_dir = os.getcwd()
 
 # shared code between the two restart functions
-def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, **kwargs):
+def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, trigger=None, **kwargs):
+    if not trigger:
+        trigger = []
+
     # declare a new docker build that adds a static binary of tilt-restart-wrapper
     # (which makes use of `entr` to watch files and restart processes) to the user's image
     df = '''
@@ -50,7 +53,7 @@ def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, *
     # triggers the process wrapper to rerun $entrypoint
     # NB: write `date` instead of just `touch`ing because `entr` doesn't respond
     # to timestamp changes, only writes (see https://github.com/eradman/entr/issues/32)
-    live_update = live_update + [run('date > {}'.format(restart_file))]
+    live_update = live_update + [run('date > {}'.format(restart_file), trigger=trigger)]
 
     # We don't need a real context. See:
     # https://github.com/tilt-dev/tilt/issues/3897
@@ -60,7 +63,8 @@ def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, *
                  live_update=live_update, **kwargs)
 
 def docker_build_with_restart(ref, context, entrypoint, live_update,
-                              base_suffix='-tilt_docker_build_with_restart_base', restart_file=RESTART_FILE, **kwargs):
+                              base_suffix='-tilt_docker_build_with_restart_base', restart_file=RESTART_FILE,
+                              trigger=None, **kwargs):
     """Wrap a docker_build call and its associated live_update steps so that the last step
     of any live update is to rerun the given entrypoint.
 
@@ -72,6 +76,8 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
       live_update: set of steps for updating a running container; as the parameter of the same name in docker_build
       base_suffix: suffix for naming the base image, applied as {ref}{base_suffix}
       restart_file: file that Tilt will update during a live_update to signal the entrypoint to rerun
+      trigger: (optional) list of local paths. If specified, the process will ONLY be restarted when there are changes
+               to the given file(s); as the parameter of the same name in the LiveUpdate `run` step.
       **kwargs: will be passed to the underlying `docker_build` call
     """
 
@@ -93,11 +99,12 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
     # relevant to building the child image / may conflict with args we specifically
     # pass for the child image.
     cleaned_kwargs = {k: v for k, v in kwargs.items() if k not in KWARGS_BLACKLIST}
-    _helper(base_ref, ref, entrypoint, live_update, restart_file, **cleaned_kwargs)
+    _helper(base_ref, ref, entrypoint, live_update, restart_file, trigger, **cleaned_kwargs)
 
 
 def custom_build_with_restart(ref, command, deps, entrypoint, live_update,
-                              base_suffix='-tilt_docker_build_with_restart_base', restart_file=RESTART_FILE, **kwargs):
+                              base_suffix='-tilt_docker_build_with_restart_base', restart_file=RESTART_FILE,
+                              trigger=None, **kwargs):
     """Wrap a custom_build call and its associated live_update steps so that the last step
     of any live update is to rerun the given entrypoint.
 
@@ -110,6 +117,8 @@ def custom_build_with_restart(ref, command, deps, entrypoint, live_update,
       live_update: set of steps for updating a running container; as the parameter of the same name in custom_build
       base_suffix: suffix for naming the base image, applied as {ref}{base_suffix}
       restart_file: file that Tilt will update during a live_update to signal the entrypoint to rerun
+      trigger: (optional) list of local paths. If specified, the process will ONLY be restarted when there are changes
+               to the given file(s); as the parameter of the same name in the LiveUpdate `run` step.
       **kwargs: will be passed to the underlying `custom_build` call
     """
 
@@ -136,4 +145,4 @@ def custom_build_with_restart(ref, command, deps, entrypoint, live_update,
 
     # A few arguments aren't applicable to the docker_build, so remove them.
     cleaned_kwargs = {k: v for k, v in kwargs.items() if k not in _CUSTOM_BUILD_KWARGS_BLACKLIST}
-    _helper(base_ref, ref, entrypoint, live_update, restart_file, **cleaned_kwargs)
+    _helper(base_ref, ref, entrypoint, live_update, restart_file, trigger, **cleaned_kwargs)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch maiamcc/trigger-restart:

6c931432023458dca9507f305c7077f231014098 (2021-01-15 12:27:37 -0500)
restart_process: optional trigger arg to only restart process when specified files change

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics

Addresses #122 