### PR TITLE
Configurable location of binary

### DIFF
--- a/min_tilt_version/Tiltfile
+++ b/min_tilt_version/Tiltfile
@@ -3,8 +3,8 @@ def min_tilt_version(min_version):
   # v0.13.0, built 2020-04-01
   # Also supports dev versions
   # v0.13.0-dev, built 2020-04-03
-
-  ver_string = str(local('tilt version', quiet=True))
+  tilt_bin = os.environ.get('TILT_BIN', 'tilt')
+  ver_string = str(local('%s version' % tilt_bin, quiet=True))
   # Clean out the version file so its in the format 0.13.0
   versions = ver_string.split(', ')
   # pull first string and remove the `v` and `-dev`


### PR DESCRIPTION
This change solves the issue of paths and other binaries conflicting with the name.

In my case, there's a RubyGem called tilt that also has the binary called tilt installed and was taking the precedence (because of the Ruby version manager).

Having the environment variable available, I can now have it configured and the check can be performed targeting the correct binary location.