### PR TITLE
Prevent fetching updates multiple times if we're already up to date

### DIFF
--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -1,3 +1,21 @@
+load('ext://global_vars', 'get_global', 'set_global')
+
+
+def _get_skip():
+    return get_global(_get_skip_name())
+
+
+def _set_skip(value):
+    set_global(_get_skip_name(), value)
+
+
+def _get_skip_name():
+    return 'HELM_REMOTE_SKIP_UPDATES'
+
+
+if _get_skip() == None:
+    _set_skip('False')  # Gets set to true after the first update, preventing further updates within the same build/instance/up
+
 
 def _find_root_tiltfile_dir():
     # Find top-level Tilt path
@@ -41,7 +59,7 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
     # ======== Helper methods
     def get_local_repo(repo_name, repo_url):
         # if no repos are present, helm exit code is >0 and stderr output buffered
-        added_helm_repos = decode_yaml(local('helm repo list --output yaml 2>/dev/null || true', command_bat='helm repo list --output yaml 2>&1 || ver>nul'))
+        added_helm_repos = decode_yaml(local('helm repo list --output yaml 2>/dev/null || true', command_bat='helm repo list --output yaml 2>&1 || ver>nul', quiet=True))
         repo = [item for item in added_helm_repos if item['name'] == chart and item['url'] == repo_url] if added_helm_repos != None else []
 
         return repo[0] if len(repo) > 0 else None
@@ -64,7 +82,7 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
 
     def fetch_chart_details(chart, repo_name, auth, version):
         command = build_helm_command('search repo %s/%s --output yaml' % (shlex.quote(repo_name), shlex.quote(chart)), None, version)
-        results = decode_yaml(local(command))
+        results = decode_yaml(local(command, quiet=True))
 
         return results[0] if len(results) > 0 else None
 
@@ -83,7 +101,7 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
 
     # Based on helm chart conventions, and the fact we don't want anyone traversing directories
     # validate is to essentially ensure there's no special characters aside from '-' being used
-    # str.isalnum accepts dots, which is only dangerous when slashes are allowed 
+    # str.isalnum accepts dots, which is only dangerous when slashes are allowed
     # https://helm.sh/docs/chart_best_practices/conventions/#chart-names
 
     if chart.replace('-', '').isalnum() == False or chart != chart.replace('.', ''):
@@ -102,15 +120,19 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
     if repo_url != '':
         local_helm_repo = get_local_repo(repo_name, repo_url)
 
-        if (local_helm_repo == None):
-            # Unaware of repo, add it 
+        if local_helm_repo == None:
+            # Unaware of repo, add it
             repo_command = 'repo add %s %s' % (shlex.quote(repo_name), shlex.quote(repo_url))
             # Add authentication for adding the repository if credentials are provided
-            local(build_helm_command(repo_command, (username, password)))
+            output = str(local(build_helm_command(repo_command, (username, password)), quiet=True)).rstrip('\n')
+            if 'already exists' not in output: # repo was added
+                _set_skip('False')
         else:
             # Helm is already aware of the chart, update repo (unfortunately you cannot specify a single repo)
-            repo_command = 'repo update'
-            local(build_helm_command(repo_command))
+            if _get_skip() != 'True':
+                repo_command = 'repo update'
+                local(build_helm_command(repo_command), quiet=True)
+                _set_skip('True')
 
     # ======== Create Namespace
     if create_namespace and namespace != '' and namespace != 'default':
@@ -124,29 +146,28 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
 
     cached_chart_exists = os.path.exists(chart_target)
 
-    pull = True
+    needs_pull = True
 
-    if cached_chart_exists == True:
+    if cached_chart_exists:
         # Helm chart structure is concrete, we can trust this YAML file to exist
         cached_chart_details = read_yaml(os.path.join(chart_target, 'Chart.yaml'))
 
         # check if our local cached chart matches latest remote
         remote_chart_details = fetch_chart_details(chart, repo_name, (username, password), version)
-        
+
         # pull when version mismatch
-        pull = cached_chart_details['version'] != remote_chart_details['version']
+        needs_pull = cached_chart_details['version'] != remote_chart_details['version']
 
 
-    if pull == True:
+    if needs_pull:
         # -------- commands
         pull_command = 'pull %s/%s --untar --destination %s' % (repo_name, chart, pull_target)
 
         # ======== Perform Installation
-        if cached_chart_exists == True:
-            local('rm -rf %s' % chart_target,
-                  command_bat='if exist %s ( rd /s /q %s )' % (chart_target, chart_target))
+        if cached_chart_exists:
+            local('rm -rf %s' % chart_target, command_bat='if exist %s ( rd /s /q %s )' % (chart_target, chart_target), quiet=True)
 
-        local(build_helm_command(pull_command, (username, password), version))
+        local(build_helm_command(pull_command, (username, password), version), quiet=True)
 
     install_crds(chart, chart_target)
 
@@ -164,18 +185,18 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
     return yaml
 
 def _version_tuple():
-  ver_string = str(local('tilt version', quiet=True))
-  versions = ver_string.split(', ')
-  # pull first string and remove the `v` and `-dev`
-  version = versions[0].replace('-dev', '').replace('v', '')
-  return [int(str_num) for str_num in version.split(".")]
+    ver_string = str(local('tilt version', quiet=True))
+    versions = ver_string.split(', ')
+    # pull first string and remove the `v` and `-dev`
+    version = versions[0].replace('-dev', '').replace('v', '')
+    return [int(str_num) for str_num in version.split(".")]
 
 # install CRDs as a separate resource and wait for them to be ready
 def install_crds(name, directory):
     name += '-crds'
-    files = str(local(r"grep --include='*.yaml' --include='*.yml' -rEil '\bkind[^\w]+CustomResourceDefinition\s*$' %s || exit 0" % directory)).strip()
+    files = str(local(r"grep --include='*.yaml' --include='*.yml' -rEil '\bkind[^\w]+CustomResourceDefinition\s*$' %s || exit 0" % directory, quiet=True)).rstrip('\n')
 
-    if (files == ''):
+    if files == '':
         files = []
     else:
         files = files.split("\n")


### PR DESCRIPTION
@nicks 

As part of its process, helm_remote() calls `helm repo update` to be sure its using the latest version of the chart. However, if the project contains multiple helm_remote() calls for different charts in the same repository, it would call `helm repo update` EACH time. This was having significant performance impacts on the time required to process the initial Tiltfile.
