### PR TITLE
ci: update ci to use ctlptl to create a cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - setup_remote_docker:
           version: 19.03.12
       - checkout
-      - run: with-kind-cluster.sh ./test.sh
+      - run: ctlptl create cluster kind --registry=ctlptl-registry && ./test.sh
         
 workflows:
   version: 2


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/ci:

e9a299adb523424b0c728bc38728df1d2b48386e (2021-03-19 19:06:39 -0400)
ci: update ci to use ctlptl to create a cluster

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics