### PR TITLE
tests: add run_all param for js tests

### DIFF
--- a/tests/javascript/README.md
+++ b/tests/javascript/README.md
@@ -15,7 +15,7 @@ Both `test_jest_npm` and `test_jest_yarn` accept the same parameters. These are:
 
 You may also pass the following optional parameters:
 * **deps (Union[str, List[str]])**: a list of files or directories to be added as dependencies to this test. Tilt will watch those files and will run the test when they change. By default, will be set to `dir`. Only accepts real paths, not file globs.
-* **run_all (bool, optional)**: by default, False. If true, Jest will run all tests at the specified dir/path(s); otherwise, just tests affected by files changed since last commit.
+* **only_changed (bool, optional)**: by default, True. If true, Jest will run tests affected by files changed since last commit; otherwise, will run all tests at the specified dir/path(s). (`only_changed = True` is equivalent to passing the [`--onlyChanged` flag](https://jestjs.io/docs/cli#--onlychanged) to Jest.)
 * **with_install (bool, optional)**: by default, False. If true, run `npm|yarn install` before running any tests, to ensure that your local dependencies are up to date.
 * **project_root (str, optional)**: if `dir` is not the root of the JS project, specify the project root here so that Tilt can locate `package.json` and your lockfile. By default, will be set to `dir`. (Mostly relevant if you have specified `with_install=True`, so that Tilt can watch your `package.json` and lockfile and rerun in the install command either changes.)
 * **ignore (List[str], optional)**: set of file patterns that will be ignored. Ignored files will not trigger builds and will not be included in images. Follows the [dockerignore syntax](https://docs.docker.com/engine/reference/builder/#dockerignore-file). Paths will be evaluated _relative to the Tiltfile_.

--- a/tests/javascript/README.md
+++ b/tests/javascript/README.md
@@ -15,6 +15,7 @@ Both `test_jest_npm` and `test_jest_yarn` accept the same parameters. These are:
 
 You may also pass the following optional parameters:
 * **deps (Union[str, List[str]])**: a list of files or directories to be added as dependencies to this test. Tilt will watch those files and will run the test when they change. By default, will be set to `dir`. Only accepts real paths, not file globs.
+* **run_all (bool, optional)**: by default, False. If true, Jest will run all tests at the specified dir/path(s); otherwise, just tests affected by files changed since last commit.
 * **with_install (bool, optional)**: by default, False. If true, run `npm|yarn install` before running any tests, to ensure that your local dependencies are up to date.
 * **project_root (str, optional)**: if `dir` is not the root of the JS project, specify the project root here so that Tilt can locate `package.json` and your lockfile. By default, will be set to `dir`. (Mostly relevant if you have specified `with_install=True`, so that Tilt can watch your `package.json` and lockfile and rerun in the install command either changes.)
 * **ignore (List[str], optional)**: set of file patterns that will be ignored. Ignored files will not trigger builds and will not be included in images. Follows the [dockerignore syntax](https://docs.docker.com/engine/reference/builder/#dockerignore-file). Paths will be evaluated _relative to the Tiltfile_.
@@ -46,3 +47,9 @@ You may also pass the following optional parameters:
                 trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
     ```
    The `trigger_mode` and `auto_init` parameters will be passed to the underlying `test` call (see docs on [Manual Update Control](https://docs.tilt.dev/manual_update_control.html)).
+
+4. Run only tests related to file changed since the last commit--except in CI mode, which should run _all_ tests
+    ```python
+    test_jest_yarn('test-js', './web',
+                      run_all=config.tilt_subcommand == 'ci')
+    ```

--- a/tests/javascript/Tiltfile
+++ b/tests/javascript/Tiltfile
@@ -2,7 +2,7 @@
 # (see docs: https://docs.tilt.dev/tests_in_tilt.html)
 
 
-def _test_js(name, pkmanager, dir, deps=None, run_all=False, with_install=False, project_root='', ignore=None, extra_args=None, **kwargs):
+def _test_js(name, pkmanager, dir, deps=None, only_changed=True, with_install=False, project_root='', ignore=None, extra_args=None, **kwargs):
     if not project_root:
         project_root = dir
 
@@ -19,12 +19,13 @@ def _test_js(name, pkmanager, dir, deps=None, run_all=False, with_install=False,
     if extra_args:
         extra_args_str = ' '.join(extra_args)
 
-    run_some_flag = '-o'
-    if run_all:
-        run_some_flag = ''
+    # https://jestjs.io/docs/cli#--onlychanged
+    only_changed_flag = '-o'  # by default, run tests for files changed since last commit
+    if not only_changed:
+        only_changed_flag = ''
 
-    cmd = 'cd {dir} && {pkmanager} test {run_some_flag} --watchAll=false {extra_args_str}'.format(
-        dir=dir, pkmanager=pkmanager, run_some_flag=run_some_flag, extra_args_str=extra_args_str)
+    cmd = 'cd {dir} && {pkmanager} test {only_changed_flag} --watchAll=false {extra_args_str}'.format(
+        dir=dir, pkmanager=pkmanager, only_changed_flag=only_changed_flag, extra_args_str=extra_args_str)
 
     file_deps = deps
     if not file_deps:
@@ -37,10 +38,10 @@ def _test_js(name, pkmanager, dir, deps=None, run_all=False, with_install=False,
     test(name, cmd, deps=file_deps, ignore=all_ignores, resource_deps=resource_deps, **kwargs)
 
 
-def test_jest_npm(name, dir, deps=None, run_all=False, with_install=False, project_root='', ignore=None, extra_args=None, **kwargs):
+def test_jest_npm(name, dir, deps=None, only_changed=True, with_install=False, project_root='', ignore=None, extra_args=None, **kwargs):
     _test_js(name, 'npm', dir,
              deps=deps,
-             run_all=run_all,
+             only_changed=only_changed,
              with_install=with_install,
              project_root=project_root,
              ignore=ignore,
@@ -48,10 +49,10 @@ def test_jest_npm(name, dir, deps=None, run_all=False, with_install=False, proje
              **kwargs)
 
 
-def test_jest_yarn(name, dir, deps=None, run_all=False, with_install=False, project_root='', ignore=None, extra_args=None, **kwargs):
+def test_jest_yarn(name, dir, deps=None, only_changed=True, with_install=False, project_root='', ignore=None, extra_args=None, **kwargs):
     _test_js(name, 'yarn', dir,
              deps=deps,
-             run_all=run_all,
+             only_changed=only_changed,
              with_install=with_install,
              project_root=project_root,
              ignore=ignore,

--- a/tests/javascript/Tiltfile
+++ b/tests/javascript/Tiltfile
@@ -2,7 +2,7 @@
 # (see docs: https://docs.tilt.dev/tests_in_tilt.html)
 
 
-def _test_js(name, pkmanager, dir, deps=None, with_install=False, project_root='', ignore=None, extra_args=None, **kwargs):
+def _test_js(name, pkmanager, dir, deps=None, run_all=False, with_install=False, project_root='', ignore=None, extra_args=None, **kwargs):
     if not project_root:
         project_root = dir
 
@@ -19,8 +19,12 @@ def _test_js(name, pkmanager, dir, deps=None, with_install=False, project_root='
     if extra_args:
         extra_args_str = ' '.join(extra_args)
 
-    cmd = 'cd {dir} && {pkmanager} test -o --watchAll=false {extra_args_str}'.format(
-        dir=dir, pkmanager=pkmanager, extra_args_str=extra_args_str)
+    run_some_flag = '-o'
+    if run_all:
+        run_some_flag = ''
+
+    cmd = 'cd {dir} && {pkmanager} test {run_some_flag} --watchAll=false {extra_args_str}'.format(
+        dir=dir, pkmanager=pkmanager, run_some_flag=run_some_flag, extra_args_str=extra_args_str)
 
     file_deps = deps
     if not file_deps:
@@ -33,12 +37,26 @@ def _test_js(name, pkmanager, dir, deps=None, with_install=False, project_root='
     test(name, cmd, deps=file_deps, ignore=all_ignores, resource_deps=resource_deps, **kwargs)
 
 
-def test_jest_npm(name, dir, deps=None, with_install=False, project_root='', ignore=None, extra_args=None, **kwargs):
-    _test_js(name, 'npm', dir, deps, with_install, project_root, ignore, extra_args, **kwargs)
+def test_jest_npm(name, dir, deps=None, run_all=False, with_install=False, project_root='', ignore=None, extra_args=None, **kwargs):
+    _test_js(name, 'npm', dir,
+             deps=deps,
+             run_all=run_all,
+             with_install=with_install,
+             project_root=project_root,
+             ignore=ignore,
+             extra_args=extra_args,
+             **kwargs)
 
 
-def test_jest_yarn(name, dir, deps=None, with_install=False, project_root='', ignore=None, extra_args=None, **kwargs):
-    _test_js(name, 'yarn', dir, deps, with_install, project_root, ignore, extra_args, **kwargs)
+def test_jest_yarn(name, dir, deps=None, run_all=False, with_install=False, project_root='', ignore=None, extra_args=None, **kwargs):
+    _test_js(name, 'yarn', dir,
+             deps=deps,
+             run_all=run_all,
+             with_install=with_install,
+             project_root=project_root,
+             ignore=ignore,
+             extra_args=extra_args,
+             **kwargs)
 
 
 def verify_dep(f):

--- a/tests/javascript/test/Tiltfile
+++ b/tests/javascript/test/Tiltfile
@@ -24,5 +24,9 @@ elif arg == 'install-without-project-root':
 elif arg == 'set-trigger-mode-via-kwargs':
     test_jest_yarn('tests', './fake_project_yarn/src/',
                    trigger_mode=TRIGGER_MODE_MANUAL)
+elif arg == 'run-all-tests':
+    test_jest_yarn('tests', './fake_project_yarn/src/',
+                   run_all=True)
+
 else:
     fail('unrecognized arg: {}'.format(arg))

--- a/tests/javascript/test/Tiltfile
+++ b/tests/javascript/test/Tiltfile
@@ -26,7 +26,7 @@ elif arg == 'set-trigger-mode-via-kwargs':
                    trigger_mode=TRIGGER_MODE_MANUAL)
 elif arg == 'run-all-tests':
     test_jest_yarn('tests', './fake_project_yarn/src/',
-                   run_all=True)
+                   only_changed=False)
 
 else:
     fail('unrecognized arg: {}'.format(arg))

--- a/tests/javascript/test/Tiltfile.test
+++ b/tests/javascript/test/Tiltfile.test
@@ -56,7 +56,10 @@ def assert_resource_deps(m, expected):
              format(m['Name'], expected, actual))
 
 
-def assert_cmd_contains(m, expected):
+def assert_cmd_contains(m, expected, not_expected=None):
+    if not not_expected:
+        not_expected = []
+
     argv = m.get('DeployTarget', {}).get('UpdateCmd', {}).get('Argv', [])
     if not len(argv) == 3:
         fail('expected UpdateCmd for {} to have 3 args, instead found: {}'.format(m['Name'], argv))
@@ -71,6 +74,11 @@ def assert_cmd_contains(m, expected):
         if not str_contains(cmd, exp):
             fail('expected UpdateCmd for {} to contain "{}", but didn\'t (full cmd: "{}")'.
                  format(m['Name'], exp, cmd))
+
+    for not_exp in not_expected:
+        if str_contains(cmd, not_exp):
+            fail('expected UpdateCmd for {} NOT to contain "{}", but it did (full cmd: "{}")'.
+                 format(m['Name'], not_exp, cmd))
 
 
 def assert_trigger_mode(m, expected):
@@ -145,6 +153,16 @@ def test_set_trigger_mode_via_kwargs():
     assert_cmd_contains(test_manifest, ['cd ./fake_project_yarn/src', 'yarn test -o --watchAll=false'])
     assert_trigger_mode(test_manifest, 1)  # trigger mode manual = 1
 
+
+def test_run_all_tests():
+    res = get_tiltfile_res_for_test_case('run-all-tests')
+    test_manifest = assert_manifest_names(res, ['tests'])[0]
+
+    assert_resource_deps(test_manifest, [])
+    assert_deps(test_manifest, ['fake_project_yarn/src'])
+    assert_cmd_contains(test_manifest, ['cd ./fake_project_yarn/src', 'yarn test', '--watchAll=false'],
+                        not_expected=['-o'])
+
 test_no_install()
 print()
 
@@ -161,6 +179,9 @@ test_install_without_project_root()
 print()
 
 test_set_trigger_mode_via_kwargs()
+print()
+
+test_run_all_tests()
 print()
 
 # Without at least one real resource, `tilt ci` exits with code 1 😅


### PR DESCRIPTION
need this so that the CI tests in https://github.com/tilt-dev/tilt-example-nodejs/pull/12 actually do anything useful