### PR TITLE
extensions: fix timeout test

### DIFF
--- a/tests/golang/test/fake_project/slow/slow_test.go
+++ b/tests/golang/test/fake_project/slow/slow_test.go
@@ -6,7 +6,9 @@ import (
 	"time"
 )
 
+// This is invoked with a small `go test -timeout` to test the extension's timeout setting
 func TestSlightlySlow(t *testing.T) {
-	time.Sleep(time.Millisecond*3)
+	// small durations such as 3ms apparently allow a `go test -timeout 1ms` to still succeed
+	time.Sleep(time.Second)
 	fmt.Println("nothing to see here...")
 }


### PR DESCRIPTION
This failed in CI thus:
```
Tilt analytics disabled: Environment variable CI=true

Initial Build • (Tiltfile)
Beginning Tiltfile execution
Successfully loaded Tiltfile (50.222921ms)
      timeout │ 
      timeout │ Initial Build • timeout
      timeout │ STEP 1/1 — Running command: [sh -c go test   -timeout 1ms  ./fake_project/slow] (in "/tmp/tmp.1umcuVhG0e/tests/golang/test")
      timeout │ ok  	_/tmp/tmp.1umcuVhG0e/tests/golang/test/fake_project/slow	0.037s
      timeout │      Step 1 - 0.00s (Running command: [sh -c go test   -timeout 1ms  ./fake_project/slow] (in "/tmp/tmp.1umcuVhG0e/tests/golang/test"))
      timeout │      DONE IN: 0.55s 
      timeout │ 
      timeout │ 
SUCCESS. All workloads are healthy.
+ msg_and_exit 'Expected '\''tilt ci'\'' to fail, but succeeded.'
+ echo 'Expected '\''tilt ci'\'' to fail, but succeeded.'
Expected 'tilt ci' to fail, but succeeded.
+ exit 1
make: *** [Makefile:82: test-extensions] Error 1
```

The go test sleeps for 3ms, with the intent of causing `go test -timeout 1ms` to fail with a timeout. I tried reproing this 1000 times on my laptop and failed, so I wasn't able to verify the fix. This is basically just a hunch based on experience with times as small as that making things racy.