### PR TITLE
Allow user to specify which user will be set with restart_process

### DIFF
--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -23,7 +23,7 @@ _CUSTOM_BUILD_KWARGS_BLACKLIST = [
 _ext_dir = os.getcwd()
 
 # shared code between the two restart functions
-def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, trigger=None, user=root, **kwargs):
+def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, trigger=None, user='root', **kwargs):
     if not trigger:
         trigger = []
 
@@ -65,7 +65,7 @@ def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, t
 
 def docker_build_with_restart(ref, context, entrypoint, live_update,
                               base_suffix='-tilt_docker_build_with_restart_base', restart_file=RESTART_FILE,
-                              trigger=None, user=root, **kwargs):
+                              trigger=None, user='root', **kwargs):
     """Wrap a docker_build call and its associated live_update steps so that the last step
     of any live update is to rerun the given entrypoint.
 
@@ -106,7 +106,7 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
 
 def custom_build_with_restart(ref, command, deps, entrypoint, live_update,
                               base_suffix='-tilt_docker_build_with_restart_base', restart_file=RESTART_FILE,
-                              trigger=None, user=root, **kwargs):
+                              trigger=None, user='root', **kwargs):
     """Wrap a custom_build call and its associated live_update steps so that the last step
     of any live update is to rerun the given entrypoint.
 

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -23,7 +23,7 @@ _CUSTOM_BUILD_KWARGS_BLACKLIST = [
 _ext_dir = os.getcwd()
 
 # shared code between the two restart functions
-def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, trigger=None, **kwargs):
+def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, trigger=None, user=root, **kwargs):
     if not trigger:
         trigger = []
 
@@ -37,7 +37,8 @@ def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, t
     RUN ["touch", "{}"]
     COPY --from=restart-helper /tilt-restart-wrapper /
     COPY --from=restart-helper /entr /
-    '''.format(base_ref, restart_file)
+    USER {}
+    '''.format(base_ref, restart_file, user)
 
     # Change the entrypoint to use `tilt-restart-wrapper`.
     # `tilt-restart-wrapper` makes use of `entr` (https://github.com/eradman/entr/) to
@@ -64,7 +65,7 @@ def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, t
 
 def docker_build_with_restart(ref, context, entrypoint, live_update,
                               base_suffix='-tilt_docker_build_with_restart_base', restart_file=RESTART_FILE,
-                              trigger=None, **kwargs):
+                              trigger=None, user=root, **kwargs):
     """Wrap a docker_build call and its associated live_update steps so that the last step
     of any live update is to rerun the given entrypoint.
 
@@ -78,6 +79,7 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
       restart_file: file that Tilt will update during a live_update to signal the entrypoint to rerun
       trigger: (optional) list of local paths. If specified, the process will ONLY be restarted when there are changes
                to the given file(s); as the parameter of the same name in the LiveUpdate `run` step.
+      user: (optional) the user to set on the image after the live_update files are copied in
       **kwargs: will be passed to the underlying `docker_build` call
     """
 
@@ -99,12 +101,12 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
     # relevant to building the child image / may conflict with args we specifically
     # pass for the child image.
     cleaned_kwargs = {k: v for k, v in kwargs.items() if k not in KWARGS_BLACKLIST}
-    _helper(base_ref, ref, entrypoint, live_update, restart_file, trigger, **cleaned_kwargs)
+    _helper(base_ref, ref, entrypoint, live_update, restart_file, trigger, user, **cleaned_kwargs)
 
 
 def custom_build_with_restart(ref, command, deps, entrypoint, live_update,
                               base_suffix='-tilt_docker_build_with_restart_base', restart_file=RESTART_FILE,
-                              trigger=None, **kwargs):
+                              trigger=None, user=root, **kwargs):
     """Wrap a custom_build call and its associated live_update steps so that the last step
     of any live update is to rerun the given entrypoint.
 
@@ -119,6 +121,7 @@ def custom_build_with_restart(ref, command, deps, entrypoint, live_update,
       restart_file: file that Tilt will update during a live_update to signal the entrypoint to rerun
       trigger: (optional) list of local paths. If specified, the process will ONLY be restarted when there are changes
                to the given file(s); as the parameter of the same name in the LiveUpdate `run` step.
+      user: (optional) the user that should be set on the image after the live_update files are copied in
       **kwargs: will be passed to the underlying `custom_build` call
     """
 
@@ -145,4 +148,4 @@ def custom_build_with_restart(ref, command, deps, entrypoint, live_update,
 
     # A few arguments aren't applicable to the docker_build, so remove them.
     cleaned_kwargs = {k: v for k, v in kwargs.items() if k not in _CUSTOM_BUILD_KWARGS_BLACKLIST}
-    _helper(base_ref, ref, entrypoint, live_update, restart_file, trigger, **cleaned_kwargs)
+    _helper(base_ref, ref, entrypoint, live_update, restart_file, trigger, user, **cleaned_kwargs)

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -79,7 +79,7 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
       restart_file: file that Tilt will update during a live_update to signal the entrypoint to rerun
       trigger: (optional) list of local paths. If specified, the process will ONLY be restarted when there are changes
                to the given file(s); as the parameter of the same name in the LiveUpdate `run` step.
-      user: (optional) the user to set on the image after the live_update files are copied in
+      user: (optional) the user to set on the image after the restart-helper files are copied in
       **kwargs: will be passed to the underlying `docker_build` call
     """
 
@@ -121,7 +121,7 @@ def custom_build_with_restart(ref, command, deps, entrypoint, live_update,
       restart_file: file that Tilt will update during a live_update to signal the entrypoint to rerun
       trigger: (optional) list of local paths. If specified, the process will ONLY be restarted when there are changes
                to the given file(s); as the parameter of the same name in the LiveUpdate `run` step.
-      user: (optional) the user that should be set on the image after the live_update files are copied in
+      user: (optional) the user that should be set on the image after the restart-helper files are copied in
       **kwargs: will be passed to the underlying `custom_build` call
     """
 


### PR DESCRIPTION
Adds a `user` argument that will be used to set `USER` in the Dockerfile created with the `restart-helper` files.

I originally opened https://github.com/tilt-dev/tilt/pull/4466 with a different version of this and @maiamcc said I should put a note here to make sure and pull these changes into the integration tests for `tilt-dev/tilt`.