### PR TITLE
Add a tilt_inspector extension that lets you navigate internal tilt state

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`snyk`](/snyk): Use [Snyk](https://snyk.io) to test your containers, configuration files, and open source dependencies.
 - [`syncback`](/syncback): Sync files/directories from your container back to your local FS.
 - [`tests`](/tests): Some common configurations for running your tests in Tilt.
+- [`tilt_inspector`](/tilt_inspector): Debugging server for exploring internal Tilt state.
 - [`wait_for_it`](/wait_for_it): Wait until command output is equal to given output.
 
 ## Contribute an Extension

--- a/test.sh
+++ b/test.sh
@@ -18,5 +18,6 @@ ko/test/test.sh
 
 secret/test/test.sh
 restart_process/test/test.sh
+tilt_inspector/test/test.sh
 tests/golang/test/test.sh
 tests/javascript/test/test.sh

--- a/tilt_inspector/README.md
+++ b/tilt_inspector/README.md
@@ -1,0 +1,22 @@
+# Tilt Inspsector
+
+Author: [Nick Santos](https://github.com/nicks)
+
+A small debugging server for viewing internal Tilt state.
+
+## Functions
+
+### tilt_inspector(port: int = 11350)
+
+Exposes a tilt inspector server at the given port.
+
+## Example Usage
+
+```
+load('ext://tilt_inspector', 'tilt_inspector')
+tilt_inspector()
+```
+
+## Other notes
+
+One tilt inspector server can inspect arbitrarily many tilt instances.

--- a/tilt_inspector/Tiltfile
+++ b/tilt_inspector/Tiltfile
@@ -1,0 +1,21 @@
+# -*- mode: Python -*-
+
+_img = 'tiltdev/tilt-inspector:v20210426'
+
+def tilt_inspector(port=11351):
+  home_dir = os.getenv('HOME')
+  local_resource(
+    name="tilt:inspector",
+    deps=[],
+    cmd="docker pull %s" % _img,
+    serve_cmd=[
+      'docker', 'run', '--rm=true',
+      '--network=host',
+      '--entrypoint', './node_modules/.bin/next',
+      '-v', '%s:/root/.tilt-dev' % os.path.join(home_dir, '.tilt-dev'),
+      '-v', '%s:/root/.windmill' % os.path.join(home_dir, '.windmill'),
+      _img,
+      'start',
+      '--port', '%d' % port
+    ],
+    links=['http://localhost:%d/' % port])

--- a/tilt_inspector/test/Tiltfile
+++ b/tilt_inspector/test/Tiltfile
@@ -1,0 +1,3 @@
+load('../Tiltfile', 'tilt_inspector')
+
+tilt_inspector()

--- a/tilt_inspector/test/test.sh
+++ b/tilt_inspector/test/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+set -ex
+tilt ci
+tilt down --delete-namespaces


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/tilt-inspector:

c10f43cfe4a9490d8e95f46e3fb679e6bf9fa9f0 (2021-04-26 13:03:06 -0400)
Add a tilt_inspector extension that lets you navigate internal tilt state

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics