### PR TITLE
restart_process: solve prob with permissions on restart file by just moving the restart file

### DIFF
--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -78,7 +78,7 @@ If you see an error of the form:
 ```
 ERROR: Build Failed: ImageBuild: executor failed running [touch /tmp/.restart-proc']: exit code: 1
 ```
-this often means that your Dockerfile user doesn't have permission to write to the file we use to signal a process restart. Use the `restart_file` parameter to specify a file that your Dockerfile user definitely has write access to.
+this often means that your Dockerfile user ([see docs](https://docs.docker.com/engine/reference/builder/#user)) doesn't have permission to write to the file we use to signal a process restart. Use the `restart_file` parameter to specify a file that your Dockerfile user definitely has write access to.
 
 ### API
 ```python

--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -18,9 +18,8 @@ E.g. if your app is a static binary, you'll probably need to re-execute the bina
 
 ### Unsupported Cases
 This extension does NOT support process restarts for:
-- Images built with `custom_build`
+- Images built with `custom_build` using any of the `skips_local_docker`, `disable_push`, or `tag` parameters.
 - Images run in Docker Compose resources (use the [`restart_container()`](https://docs.tilt.dev/api.html#api.restart_container) builtin instead)
-- `custom_build`
 - Images without a shell (e.g. `scratch`, `distroless`)
 - Container commands specified as `command` in Kubernetes YAML will be overridden by this extension.
   - However, the `args` field is still available; [reach out](https://tilt.dev/contact) if you need help navigating the interplay between Tilt and these YAML values
@@ -72,6 +71,14 @@ custom_build_with_restart(
     live_update=[sync(...)]
 )
 ```
+
+### Troubleshooting
+#### `failed running [touch /tmp/.restart-proc']`
+If you see an error of the form:
+```
+ERROR: Build Failed: ImageBuild: executor failed running [touch /tmp/.restart-proc']: exit code: 1
+```
+this often means that your Dockerfile user doesn't have permission to write to the file we use to signal a process restart. Use the `restart_file` parameter to specify a file that your Dockerfile user definitely has write access to.
 
 ### API
 ```python

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -1,4 +1,4 @@
-RESTART_FILE = '/.restart-proc'
+RESTART_FILE = '/tmp/.restart-proc'
 TYPE_RESTART_CONTAINER_STEP = 'live_update_restart_container_step'
 
 KWARGS_BLACKLIST = [
@@ -9,10 +9,9 @@ KWARGS_BLACKLIST = [
     # 'target' isn't relevant to our child build--if we pass this arg,
     # Docker will just fail to find the specified stage and error out
     'target',
-
 ]
 
-# Arguments in custom_build but don't apply to the docker_build.
+# Arguments to custom_build that don't apply to the docker_build.
 _CUSTOM_BUILD_KWARGS_BLACKLIST = [
     'tag',
     'command_bat',
@@ -33,7 +32,6 @@ def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, t
     FROM tiltdev/restart-helper:2020-10-16 as restart-helper
 
     FROM {}
-    USER root
     RUN ["touch", "{}"]
     COPY --from=restart-helper /tilt-restart-wrapper /
     COPY --from=restart-helper /entr /
@@ -57,7 +55,7 @@ def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, t
 
     # We don't need a real context. See:
     # https://github.com/tilt-dev/tilt/issues/3897
-    context=_ext_dir
+    context = _ext_dir
 
     docker_build(ref, context, entrypoint=entrypoint_with_entr, dockerfile_contents=df,
                  live_update=live_update, **kwargs)
@@ -67,7 +65,6 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
                               trigger=None, **kwargs):
     """Wrap a docker_build call and its associated live_update steps so that the last step
     of any live update is to rerun the given entrypoint.
-
 
      Args:
       ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'); as the parameter of the same name in docker_build
@@ -86,7 +83,7 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
         fail("`docker_build_with_restart` requires at least one live_update step")
     for step in live_update:
         if type(step) == TYPE_RESTART_CONTAINER_STEP:
-            fail("`docker_build_with_restart` is not compatible with live_update step: "+
+            fail("`docker_build_with_restart` is not compatible with live_update step: " +
                  "`restart_container()` (this extension is meant to REPLACE restart_container() )")
 
     # rename the original image to make it a base image and declare a docker_build for it
@@ -107,7 +104,6 @@ def custom_build_with_restart(ref, command, deps, entrypoint, live_update,
                               trigger=None, **kwargs):
     """Wrap a custom_build call and its associated live_update steps so that the last step
     of any live update is to rerun the given entrypoint.
-
 
      Args:
       ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'); as the parameter of the same name in custom_build
@@ -137,7 +133,6 @@ def custom_build_with_restart(ref, command, deps, entrypoint, live_update,
             fail("`custom_build_with_restart` is not compatible with `disable_push`")
         if k == 'tag':
             fail("`custom_build_with_restart` renames your base image, so is not compatible with `tag`")
-
 
     # rename the original image to make it a base image and declare a custom_build for it
     base_ref = '{}{}'.format(ref, base_suffix)


### PR DESCRIPTION
The restart_process extension previously ran into trouble when handling Dockerfiles with non-root users: such a DF wouldn't be able to `touch /.restart-proc` (the default file used to signal a process restart) -- see #52

We worked around this with #62: regardless of the user in the initial Dockerfile, set the user to `root` so we're sure to have permissions for `/.restart-proc`.

This worked okay, but was still a pain for ppl who wanted their subsequent live updates to be run with the user set in their Dockerfile rather than as root (see #98). We even had a user-submitted fix (#162) -- which would cause other, different problems, because presumably live updates as the original non-root user wouldn't have permissions on the `/.restart-proc` file created as `root`.

Rather than increasingly complicated code for changing the Dockerfile user and changing it back, I propose we do the following:
1. change the default path for the file that signals restarts to be `/tmp/.restart-proc` -- `/tmp` is significantly more likely to be writable by a non-root user by default, which obviates our need to change users at all
2. for cases where someone gets permission errors for `/tmp/.restart-proc`, rather than trying to solve the problem by manipulating the dockerfile/the user, instead we direct them to use the `restart_file` param to specify a restart file that they _will_ have permissions for with their current user. (I wish there was a good way to detect this error at runtime and surface useful instructions -- we'll just have to settle for putting it in the README for now :-/ )

TODO: when this is landed, update Tilt integration tests to use the latest version of `restart_process`