### PR TITLE
restart_process: run goimports so we can import this into tilt without linter complaining

### DIFF
--- a/restart_process/tilt-restart-wrapper.go
+++ b/restart_process/tilt-restart-wrapper.go
@@ -67,7 +67,7 @@ func main() {
 	}
 
 	if len(flag.Args()) == 0 {
-		log.Fatal("`tilt-restart-wrapper` requires at least one positional arg "+
+		log.Fatal("`tilt-restart-wrapper` requires at least one positional arg " +
 			"(will be passed to `entr` and executed / rerun whenever `watch_file` changes)")
 	}
 }


### PR DESCRIPTION
this will fix [these tests failures](https://app.circleci.com/pipelines/github/tilt-dev/tilt/7270/workflows/8633c63b-2a7e-4990-9d1b-91d962c5e093/jobs/62876) in https://github.com/tilt-dev/tilt/pull/4497 sobbb