### PR TITLE
Add --from-env-file option to secret extension

### DIFF
--- a/secret/Tiltfile
+++ b/secret/Tiltfile
@@ -1,6 +1,6 @@
 # -*- mode: Python -*-
 
-def secret_yaml_generic(name, namespace="", from_file=None, from_env_file=None, secret_type=None):
+def secret_yaml_generic(name, namespace="", from_file=None, secret_type=None, from_env_file=None):
   """Returns YAML for a generic secret
 
   Args:
@@ -8,8 +8,8 @@ def secret_yaml_generic(name, namespace="", from_file=None, from_env_file=None, 
     namespace: The namespace.
     from_file: Use the from-file secret generator. May be a string or a list of strings.
        Example: ["ssh--privatekey=path/to/id_rsa", "ssh-publickey=path/to/id_rsa.pub"]
-    from_env_file: Use the from-env-file secret generator. Can only be a string, which is the path to the env file.
-       Example: ".env"
+    from_env_file: Specify the path to a file to read lines of key=val pairs to create a secret
+      (i.e. a Docker .env file)
     secret_type (optional): Specify the type of the secret
       Example: 'kubernetes.io/dockerconfigjson'
 
@@ -59,7 +59,7 @@ def secret_yaml_generic(name, namespace="", from_file=None, from_env_file=None, 
   args.extend(["-o=yaml", "--dry-run=client"])
   return local(args)
 
-def secret_create_generic(name, namespace="", from_file=None, from_env_file=None, secret_type=None):
+def secret_create_generic(name, namespace="", from_file=None, secret_type=None, from_env_file=None):
   """Creates a secret in the current Kubernetes cluster.
 
   Args:
@@ -67,9 +67,9 @@ def secret_create_generic(name, namespace="", from_file=None, from_env_file=None
     namespace: The namespace.
     from_file: Use the from-file secret generator. May be a string or a list of strings.
       Example: ["ssh--privatekey=path/to/id_rsa", "ssh-publickey=path/to/id_rsa.pub"]
-    from_env_file: Use the from-env-file secret generator. Can only be a string, which is the path to the env file.
-       Example: ".env"
+    from_env_file: Specify the path to a file to read lines of key=val pairs to create a secret
+      (i.e. a Docker .env file)
     secret_type (optional): Specify the type of the secret
       Example: 'kubernetes.io/dockerconfigjson'
   """
-  k8s_yaml(secret_yaml_generic(name, namespace, from_file, from_env_file, secret_type))
+  k8s_yaml(secret_yaml_generic(name, namespace, from_file, secret_type, from_env_file))


### PR DESCRIPTION
K8s secrets can be created using a .env file using the `--from-env-file` argument, which this adds support for.