### PR TITLE
cert_manager: retry creating test certificate for 90s

### DIFF
--- a/cert_manager/README.md
+++ b/cert_manager/README.md
@@ -12,15 +12,15 @@ load('ext://cert_manager', 'deploy_cert_manager')
 deploy_cert_manager()
 ```
 
-This will deploy cert-manager to you cluster and checks it actually works.
+This will deploy cert-manager to your cluster and check that it actually works.
 
-If working with Kind, its is possible to pass `load_to_kind=True` to `deploy_cert_manager` so
-all the cert-manager images will be pre-pulled to your local environment and then loaded into Kind before installing. 
+If working with Kind, it's possible to pass `load_to_kind=True` to `deploy_cert_manager` so
+all the cert-manager images will be pre-pulled to your local environment and then loaded into Kind before installing.
 This speeds up your workflow if you're repeatedly destroying and recreating your kind cluster, as it doesn't
 have to pull the images over the network each time.
 
 The full list of parameters accepted by `deploy_cert_manager` includes:
 - `registry` from which images should be pulled, defaults to `quay.io/jetstack`
-- `version` of cert-manager to install, defaults to `v1.1.0`
+- `version` of cert-manager to install, defaults to `v1.3.1`
 - `load_to_kind` (see above), defaults to `False`
 - `kind_cluster_name`, defaults to `kind`

--- a/cert_manager/Tiltfile
+++ b/cert_manager/Tiltfile
@@ -26,7 +26,7 @@ spec:
 """
 
 # Deploys cert manager to your environment
-def deploy_cert_manager(registry="quay.io/jetstack", version="v1.1.0", load_to_kind=False, kind_cluster_name="kind"):
+def deploy_cert_manager(registry="quay.io/jetstack", version="v1.3.1", load_to_kind=False, kind_cluster_name="kind"):
     silent=True
     if version.startswith('v0'):
       cert_manager_test_resources_versioned = cert_manager_test_resources.format(cert_manager_api_version='v1alpha2')
@@ -59,6 +59,7 @@ def deploy_cert_manager(registry="quay.io/jetstack", version="v1.1.0", load_to_k
 
     # 2. create a test certificate
     print("Testing cert-manager")
-    local("cat << EOF | kubectl apply -f - " + cert_manager_test_resources_versioned + "EOF", quiet=silent, echo_off=silent)
+    # The webhook may refuse connections initially (despite the deployment being Available), so try several times.
+    local("for i in 1 2 3 4 5 6; do (kubectl apply -f - <<EOF" + cert_manager_test_resources_versioned + "EOF\n) && break || sleep 15; done", quiet=silent, echo_off=silent)
     local("kubectl wait --for=condition=Ready --timeout=300s -n cert-manager-test certificate/selfsigned-cert ", quiet=silent, echo_off=silent)
-    local("cat << EOF | kubectl delete -f - " + cert_manager_test_resources_versioned + "EOF", quiet=silent, echo_off=silent)
+    local("kubectl delete -f - <<EOF" + cert_manager_test_resources_versioned + "EOF", quiet=silent, echo_off=silent)


### PR DESCRIPTION
Fixes kubernetes-sigs/cluster-api#4559

In using the cert_manager extension, the final test certificate step often fails with this error:

```
Beginning Tiltfile execution
Installing cert-manager
Waiting for cert-manager to start
Testing cert-manager
Traceback (most recent call last):
  /Users/matt/Projects/src/sigs.k8s.io/cluster-api-provider-azure/Tiltfile:339:24: in <toplevel>
  /Users/matt/Projects/src/sigs.k8s.io/cluster-api-provider-azure/tilt_modules/cert_manager/Tiltfile:61:10: in deploy_cert_manager
  <builtin>: in local
Error: command ["sh" "-c" "cat << EOF | kubectl apply -f - \napiVersion: v1\nkind: Namespace\nmetadata:\n  name: cert-manager-test\n---\napiVersion: cert-manager.io/v1\nkind: Issuer\nmetadata:\n  name: test-selfsigned\n  namespace: cert-manager-test\nspec:\n  selfSigned: {}\n---\napiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: selfsigned-cert\n  namespace: cert-manager-test\nspec:\n  dnsNames:\n    - example.com\n  secretName: selfsigned-cert-tls\n  issuerRef:\n    name: test-selfsigned\nEOF"] failed.
error: exit status 1
stdout: "namespace/cert-manager-test created\n"
stderr: "Error from server (InternalError): error when creating \"STDIN\": Internal error occurred: failed calling webhook \"webhook.cert-manager.io\": Post \"https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s\": dial tcp 10.96.86.42:443: connect: connection refused\nError from server (InternalError): error when creating \"STDIN\": Internal error occurred: failed calling webhook \"webhook.cert-manager.io\": Post \"https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s\": dial tcp 10.96.86.42:443: connect: connection refused\n"
```

I investigated and found even though the deployments are `Available` and the relevant pods are Running, the webhook still won't respond for some amount of time on first startup. Possibly this is what cert-manager installation docs refer to when [they say](https://cert-manager.io/docs/installation/kubernetes/#verifying-the-installation):

>  It may take a minute or so for the TLS assets required for the webhook to function to be provisioned. This may cause the webhook to take a while longer to start for the first time than other pods.

Since the Starlark language doesn't offer exception handling, and `kubectl` itself has no "retry on fail" capability, I wrote a simple shell loop to try creating the test certificate every fifteen seconds for a minute and a half before giving up. In my testing, this gets our `make tilt-up` working every time, whereas before it failed consistently.

I also updated the cert-manager default version to the current v1.3.1 and fixed some language in the README.

