### PR TITLE
uibutton: add extension for Cmd buttons [ch12082]

### DIFF
--- a/uibutton/README.md
+++ b/uibutton/README.md
@@ -1,0 +1,43 @@
+# UIButton
+
+Authors:
+ * [Matt Landis](https://github.com/landism)
+ * [Milas Bowman](https://github.com/milas)
+
+Extend the Tilt UI with custom actions for your resources.
+
+## Functions
+
+### cmd_button(name, resource, argv, text='')
+
+Creates a button for a resource that runs the given command when clicked.
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `name` | `str` | Unique ID for button |
+| `resource` | `str` | Resource to associate button with |
+| `argv` | `List[str]` | Local command to run when button is clicked |
+| `text` | `str` | Text to display on button (optional: defaults to `name`) |
+
+
+## Example Usage
+
+```
+load('ext://uibutton', 'cmd_button')
+
+# define resource 'my-resource'
+# k8s_resource('my-resource')
+
+# create a button on resource 'my-resource'
+cmd_button(name='Hello World',
+           resource='my-resource',
+           argv=['echo', 'Hello World'])
+```
+
+## Other notes
+
+The `argv` argument only accepts a list, e.g. `['echo', 'Hello World']` but not `echo 'Hello World'`.
+
+The command is executed directly; to run a script, invoke the interpreter and then pass the script as an argument, e.g. `['bash', '-c', 'echo "Hello from bash ${BASH_VERSION}"']`.
+
+Any command output will appear interleaved with the associated resource's logs.

--- a/uibutton/Tiltfile
+++ b/uibutton/Tiltfile
@@ -1,0 +1,50 @@
+def cmd_button(name, resource, argv, text=''):
+  if config.tilt_subcommand == 'down':
+    return
+
+  if not text:
+    text = name
+
+  button = {
+    "apiVersion": "tilt.dev/v1alpha1",
+    "kind": "UIButton",
+    "metadata": {
+      "name": name,
+      "annotations": {
+        "tilt.dev/resource": resource,
+      }
+    },
+    "spec": {
+      "text": text,
+      "location": {
+        "componentType": "Resource",
+        "componentID": resource,
+      }
+    }
+  }
+  cmd = {
+    "apiVersion": "tilt.dev/v1alpha1",
+    "kind": "Cmd",
+    "metadata": {
+      "name": "btn-" + name,
+      "annotations": {
+        "tilt.dev/resource": resource,
+        "tilt.dev/log-span-id": 'cmd:' + name,
+      }
+    },
+    "spec": {
+      "args": argv,
+      "dir": config.main_dir,
+      "startOn": {
+        "startAfter": _now(),
+        "uiButtons": [name],
+      },
+    }
+  }
+  local("echo %s | %s apply -f -" % (shlex.quote(str(encode_yaml_stream([button, cmd]))), sys.executable))
+
+
+def _now():
+  # this is portable across coreutils/busybox/BSD
+  # note: it's missing fractional seconds because that's not available from strftime
+  return str(local('date -u +"%Y-%m-%dT%H:%M:%S.000000Z"')).rstrip('\r\n')

--- a/uibutton/Tiltfile
+++ b/uibutton/Tiltfile
@@ -41,10 +41,13 @@ def cmd_button(name, resource, argv, text=''):
       },
     }
   }
-  local("echo %s | %s apply -f -" % (shlex.quote(str(encode_yaml_stream([button, cmd]))), sys.executable))
+
+  local('echo "${TILT_APPLY_YAML}" | %s apply -f -' % (sys.executable,),
+        env={'TILT_APPLY_YAML': str(encode_yaml_stream([button, cmd]))},
+        echo_off=True)
 
 
 def _now():
   # this is portable across coreutils/busybox/BSD
   # note: it's missing fractional seconds because that's not available from strftime
-  return str(local('date -u +"%Y-%m-%dT%H:%M:%S.000000Z"')).rstrip('\r\n')
+  return str(local('date -u +"%Y-%m-%dT%H:%M:%S.000000Z"', echo_off=True, quiet=True)).rstrip('\r\n')

--- a/uibutton/test/Tiltfile
+++ b/uibutton/test/Tiltfile
@@ -1,0 +1,5 @@
+load('../Tiltfile', 'cmd_button')
+
+local_resource('vigoda', cmd='echo "Hello from resource"')
+
+cmd_button("mybutton", "vigoda", ["bash", "-c", "echo Hello from bash ${BASH_VERSION}"], text='My Button')

--- a/uibutton/test/test.sh
+++ b/uibutton/test/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+set -ex
+tilt ci
+tilt down --delete-namespaces


### PR DESCRIPTION
Extension to make creating custom `UIButton`s for a particular
resource that run a `Cmd` on click easier.

```python
load('ext://uibutton', 'cmd_button')

# define resource 'my-resource'
# k8s_resource('my-resource')

# create a button on resource 'my-resource'
cmd_button(name='Hello World',
           resource='my-resource',
           argv=['echo', 'Hello World'])
```

~~(⚠️ Draft until next Tilt release as this will fail tests since the API isn't fully live yet)~~