### PR TITLE
configmap: Add envfile support

### DIFF
--- a/configmap/README.md
+++ b/configmap/README.md
@@ -9,18 +9,19 @@ Helper functions for creating Kubernetes configmaps.
 ### configmap_yaml
 
 ```
-configmap_yaml(name: str, namespace: str = "", from_file: Union[str, List[str]] = None, watch: bool = True): Blob
+configmap_yaml(name: str, namespace: str = "", from_file: Union[str, List[str]] = None, from_env_file: str = None, watch: bool = True): Blob
 ```
 
 Returns YAML for a config map generated from a file.
 
 * `from_file` ( str ) – equivalent to `kubectl create configmap --from-file`
+* `from_env_file` (str) - equivalent to `kubectl create configmap --from-env-file`
 * `watch` ( bool ) - auto-reload if the files change
 
 ### configmap_create
 
 ```
-configmap_create(name: str, namespace: str = "", from_file: Union[str, List[str]] = None, watch: bool = True)
+configmap_create(name: str, namespace: str = "", from_file: Union[str, List[str]] = None, from_env_file: str = None, watch: bool = True)
 ```
 
 Deploys a config map. Equivalent to

--- a/configmap/README.md
+++ b/configmap/README.md
@@ -9,7 +9,7 @@ Helper functions for creating Kubernetes configmaps.
 ### configmap_yaml
 
 ```
-configmap_yaml(name: str, namespace: str = "", from_file: Union[str, List[str]] = None, from_env_file: str = None, watch: bool = True): Blob
+configmap_yaml(name: str, namespace: str = "", from_file: Union[str, List[str]] = None, watch: bool = True, from_env_file: str = None): Blob
 ```
 
 Returns YAML for a config map generated from a file.
@@ -21,7 +21,7 @@ Returns YAML for a config map generated from a file.
 ### configmap_create
 
 ```
-configmap_create(name: str, namespace: str = "", from_file: Union[str, List[str]] = None, from_env_file: str = None, watch: bool = True)
+configmap_create(name: str, namespace: str = "", from_file: Union[str, List[str]] = None, watch: bool = True, from_env_file: str = None)
 ```
 
 Deploys a config map. Equivalent to

--- a/configmap/Tiltfile
+++ b/configmap/Tiltfile
@@ -1,6 +1,6 @@
 # -*- mode: Python -*-
 
-def configmap_yaml(name, namespace="", from_file=None, from_env_file=None, watch=True):
+def configmap_yaml(name, namespace="", from_file=None, watch=True, from_env_file=None):
   """Returns YAML for a generic configmap
 
   Args:
@@ -58,7 +58,7 @@ def configmap_yaml(name, namespace="", from_file=None, from_env_file=None, watch
   args.extend(["-o=yaml", "--dry-run=client"])
   return local(args, quiet=True)
 
-def configmap_create(name, namespace="", from_file=None, from_env_file=None, watch=True):
+def configmap_create(name, namespace="", from_file=None, watch=True, from_env_file=None):
   """Creates a configmap in the current Kubernetes cluster.
 
   Generators:

--- a/configmap/Tiltfile
+++ b/configmap/Tiltfile
@@ -1,6 +1,6 @@
 # -*- mode: Python -*-
 
-def configmap_yaml(name, namespace="", from_file=None, watch=True):
+def configmap_yaml(name, namespace="", from_file=None, from_env_file=None, watch=True):
   """Returns YAML for a generic configmap
 
   Args:
@@ -26,6 +26,10 @@ def configmap_yaml(name, namespace="", from_file=None, watch=True):
     args.extend(["-n", namespace])
 
   generator = False
+
+  if from_file and from_env_file:
+    fail("Must specify either 'from_file' OR 'from_env_file'")
+
   if from_file:
     if type(from_file) == "string":
       from_file = [from_file]
@@ -39,6 +43,14 @@ def configmap_yaml(name, namespace="", from_file=None, watch=True):
       generator = True
     else:
       fail("Bad from_file argument: %s" % from_file)
+  elif from_env_file:
+    if type(from_env_file) == "list":
+      fail("from_env_file only supports string as an input to prevent confusion with kubectl behavior of only loading the last item in a list")
+    elif type(from_env_file == "string"):
+      args.extend(["--from-env-file", from_env_file])
+      if watch:
+        watch_file(from_env_file)
+      generator = True
 
   if not generator:
     fail("No configmap generator specified")

--- a/configmap/Tiltfile
+++ b/configmap/Tiltfile
@@ -10,6 +10,8 @@ def configmap_yaml(name, namespace="", from_file=None, watch=True, from_env_file
        Example: ["grafana.ini=path/to/grafana.ini"]
     watch: Reruns the Tiltfile and re-deploys automatically if the from-files change.
        Defaults to true.
+    from_env_file: Use from-env-file configmap generator. Must be string.
+       Example: "./local.env"
 
   Returns:
     The configmap YAML as a blob
@@ -70,9 +72,9 @@ def configmap_create(name, namespace="", from_file=None, watch=True, from_env_fi
     namespace: The namespace.
     from_file: Use the from-file configmap generator. May be a string or a list of strings.
        Example: ["grafana.ini=path/to/grafana.ini"]
-    from_env_file: Use from-env-file configmap generator. Must be string.
-       Example: "./local.env"
     watch: Reruns the Tiltfile and re-deploys automatically if the from-files change.
        Defaults to true.
+    from_env_file: Use from-env-file configmap generator. Must be string.
+       Example: "./local.env"
   """
-  k8s_yaml(configmap_yaml(name, namespace, from_file, from_env_file, watch))
+  k8s_yaml(configmap_yaml(name, namespace, from_file, watch, from_env_file))

--- a/configmap/Tiltfile
+++ b/configmap/Tiltfile
@@ -58,7 +58,7 @@ def configmap_yaml(name, namespace="", from_file=None, from_env_file=None, watch
   args.extend(["-o=yaml", "--dry-run=client"])
   return local(args, quiet=True)
 
-def configmap_create(name, namespace="", from_file=None, watch=True):
+def configmap_create(name, namespace="", from_file=None, from_env_file=None, watch=True):
   """Creates a configmap in the current Kubernetes cluster.
 
   Args:
@@ -66,7 +66,9 @@ def configmap_create(name, namespace="", from_file=None, watch=True):
     namespace: The namespace.
     from_file: Use the from-file configmap generator. May be a string or a list of strings.
        Example: ["grafana.ini=path/to/grafana.ini"]
+    from_env_file: Use from-env-file configmap generator. Must be string.
+       Example: "./local.env"
     watch: Reruns the Tiltfile and re-deploys automatically if the from-files change.
        Defaults to true.
   """
-  k8s_yaml(configmap_yaml(name, namespace, from_file, watch))
+  k8s_yaml(configmap_yaml(name, namespace, from_file, from_env_file, watch))

--- a/configmap/Tiltfile
+++ b/configmap/Tiltfile
@@ -61,6 +61,10 @@ def configmap_yaml(name, namespace="", from_file=None, from_env_file=None, watch
 def configmap_create(name, namespace="", from_file=None, from_env_file=None, watch=True):
   """Creates a configmap in the current Kubernetes cluster.
 
+  Generators:
+    - from_file: Wraps kubectl from-file behavior.
+    - from_env_file: Wraps kubectl from-env-file behavior.
+
   Args:
     name: The configmap name.
     namespace: The namespace.

--- a/configmap/test/Tiltfile
+++ b/configmap/test/Tiltfile
@@ -1,7 +1,6 @@
 load('../Tiltfile', 'configmap_create')
 
 configmap_create('job-config', from_file='my-job.ini=./my-job.ini')
-k8s_yaml('job.yaml')
-
 configmap_create('env-job-config', from_env_file='my-job.env')
-k8s_yaml()
+
+k8s_yaml('job.yaml')

--- a/configmap/test/Tiltfile
+++ b/configmap/test/Tiltfile
@@ -2,3 +2,6 @@ load('../Tiltfile', 'configmap_create')
 
 configmap_create('job-config', from_file='my-job.ini=./my-job.ini')
 k8s_yaml('job.yaml')
+
+configmap_create('env-job-config', from_env_file='my-job.env')
+k8s_yaml()

--- a/configmap/test/job.yaml
+++ b/configmap/test/job.yaml
@@ -7,6 +7,15 @@ spec:
   template:
     spec:
       containers:
+      - name: configmap-env-verify
+        image: alpine
+        command: ["/bin/echo", "$(TEST_VAR)"]
+        env:
+          - name: TEST_VAR
+            valueFrom:
+              configMapKeyRef:
+                name: env-job-config
+                key: TEST_VAR
       - name: configmap-verify
         image: alpine
         command: ["cat", "/etc/my-job/my-job.ini"]

--- a/configmap/test/my-job.env
+++ b/configmap/test/my-job.env
@@ -1,1 +1,1 @@
-TEST_VAR="hello!"
+TEST_VAR="hello-env!"

--- a/configmap/test/my-job.env
+++ b/configmap/test/my-job.env
@@ -1,0 +1,1 @@
+TEST_VAR="hello!"


### PR DESCRIPTION
I ran into a local development use-case where being able to leverage kubectl from-env-file support within config map generation became very relevant. I have made the updates and extended docs and testing suite to support this updated functionality. The main gotcha with the env file loader is that it supports a singular string instead of a list of strings. This is primarily to mitigate confusion with kubectl's behavior of only loading the last provided env file when it has been provided a list of files.