### PR TITLE
ci: add timeout to test execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - setup_remote_docker:
           version: '20.10.6'
       - checkout
-      - run: ctlptl create cluster kind --registry=ctlptl-registry && ./test.sh
+      - run: ctlptl create cluster kind --registry=ctlptl-registry && timeout -v -k 60s 15m ./test.sh
 
 workflows:
   version: 2


### PR DESCRIPTION
After a bad change the other day, CI got stuck running tests for
~3 hours before I noticed.

CircleCI doesn't have a generic timeout option in YAML config,
they recommend using the `timeout` command if not using a test
framework that already supports a specific option.

As of June 2021, tests take ~7m to run in CI, so this gives a
big buffer by capping at 15m at which point it'll send `SIGTERM`.
If the tests don't shut down cleanly after another minute, it'll
send a `SIGKILL`.