### PR TITLE
ci: fix Dockerfile and update CI image

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -3,11 +3,11 @@ FROM tiltdev/tilt:latest
 # Utils for our CI
 RUN apt update && apt install -y git build-essential
 RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-COPY --from=golang:1.15-buster /usr/local/go /usr/local/go
+COPY --from=golang:1.16-buster /usr/local/go /usr/local/go
 ENV PATH=/root/go/bin:/usr/local/go/bin:$PATH
 
 RUN mkdir -p /root/go/bin
-RUN curl -sSL https://github.com/google/ko/releases/download/v0.8.1/ko_0.8.1_Linux_x86_64.tar.gz | tar xzf - ko && \
+RUN curl -sSL https://github.com/google/ko/releases/download/v0.8.3/ko_0.8.3_Linux_x86_64.tar.gz | tar xzf - ko && \
   chmod +x ko && \
   mv ko /root/go/bin/ko && \
   which ko

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   check:
     docker:
-      - image: tiltdev/tilt-extensions-ci@sha256:e1990914dbfdd357ef880110faeb1eaa68bd85b7668a54f9b7aed8e098f83c0c
+      - image: tiltdev/tilt-extensions-ci@sha256:1fef97113de8538066e67d220367d953056993aca333382aca1e91b35c907bf4
 
     steps:
       - checkout
@@ -11,7 +11,7 @@ jobs:
 
   test:
     docker:
-      - image: tiltdev/tilt-extensions-ci@sha256:e1990914dbfdd357ef880110faeb1eaa68bd85b7668a54f9b7aed8e098f83c0c
+      - image: tiltdev/tilt-extensions-ci@sha256:1fef97113de8538066e67d220367d953056993aca333382aca1e91b35c907bf4
 
     steps:
       - setup_remote_docker:


### PR DESCRIPTION
With #186 I forgot to un-revert #185 so the `Dockerfile` was out of sync with what we were actually using making updating it impossible.

This brings back the Dockerfile changes and updates the CircleCI config to use the latest pinned version using those changes (Go 1.16) + Tilt v0.21.1 (latest as of July 6), i.e. this PR's CI will run against the changes included in this PR 😓 .