### PR TITLE
Allow configmap extension to use from-literal

### DIFF
--- a/configmap/README.md
+++ b/configmap/README.md
@@ -30,6 +30,16 @@ Deploys a config map. Equivalent to
 k8s_yaml(configmap_yaml('name', from_file=[...]))
 ```
 
+### configmap_from_dict
+
+```
+configmap_from_dict(name: str, namespace: str = "", inputs: Dict[str, str]] = None): Blob
+```
+
+Returns YAML for a config map generated from a given dictionary. Nested dictionaries are not supported
+
+* `inputs` ( dict ) – equivalent to `kubectl create configmap --from-literal` for each key and value
+
 ## Example Usage
 
 ### For a Grafana config

--- a/configmap/Tiltfile
+++ b/configmap/Tiltfile
@@ -60,6 +60,35 @@ def configmap_yaml(name, namespace="", from_file=None, watch=True, from_env_file
   args.extend(["-o=yaml", "--dry-run=client"])
   return local(args, quiet=True)
 
+def configmap_from_dict(name, namespace="", inputs={}):
+    """Returns YAML for a generic configmap
+    Args:
+        name: The configmap name.
+        namespace: The namespace.
+        inputs: A dict of keys and values to use. Nesting is not supported
+    Returns:
+        The configmap YAML as a blob
+    """
+
+    args = [
+        "kubectl",
+        "create",
+        "configmap",
+        name,
+    ]
+
+    if namespace:
+        args.extend(["-n", namespace])
+
+    if type(inputs) != "dict":
+        fail("Bad argument to configmap_from_dict, inputs was not dict typed")
+
+    for k,v in inputs.items():
+        args.extend(["--from-literal", "%s=%s" % (k,v)])
+
+    args.extend(["-o=yaml", "--dry-run=client"])
+    return local(args, quiet=True)
+
 def configmap_create(name, namespace="", from_file=None, watch=True, from_env_file=None):
   """Creates a configmap in the current Kubernetes cluster.
 

--- a/configmap/test/Tiltfile
+++ b/configmap/test/Tiltfile
@@ -1,6 +1,7 @@
-load('../Tiltfile', 'configmap_create')
+load('../Tiltfile', 'configmap_create', 'configmap_from_dict')
 
 configmap_create('job-config', from_file='my-job.ini=./my-job.ini')
 configmap_create('env-job-config', from_env_file='my-job.env')
+configmap_from_dict('from-dict-config', inputs={"hello":"world"})
 
 k8s_yaml('job.yaml')


### PR DESCRIPTION
Hi all!

We're big fans of this extension at my company. Internally, we've found it handy to be able to leverage the `--from-literal` option on the same command. This change adds a new function to make that option accessible through the module. 

Thanks!