### PR TITLE
syncback: fix namespace escaping

### DIFF
--- a/syncback/krsync.sh
+++ b/syncback/krsync.sh
@@ -19,7 +19,7 @@ if [ -z "$KRSYNC_STARTED" ]; then
 fi
 
 # Running as --rsh
-namespace=''
+namespace_args=()
 depl=$1
 shift
 
@@ -27,7 +27,7 @@ shift
 if [ "X$depl" = "X-l" ]; then
     depl=$1
     shift
-    namespace="-n $1"
+    namespace_args=(-n "$1")
     shift
 fi
 
@@ -38,8 +38,8 @@ exit_code="$?"
 set -e
 if [[ "$exit_code" != "0" ]]; then
   # shellcheck disable=SC2002
-  cat "$tar_path_local" | kubectl "$namespace" exec -i "$K8S_OBJECT" -- tar -xf - -C /bin/
+  cat "$tar_path_local" | kubectl "${namespace_args[@]}" exec -i "$K8S_OBJECT" -- tar -xf - -C /bin/
 fi
 
-exec kubectl "$namespace" exec -i "$K8S_OBJECT" -- "$@"
+exec kubectl "${namespace[@]}" exec -i "$K8S_OBJECT" -- "$@"
 

--- a/syncback/krsync.sh
+++ b/syncback/krsync.sh
@@ -41,5 +41,5 @@ if [[ "$exit_code" != "0" ]]; then
   cat "$tar_path_local" | kubectl "${namespace_args[@]}" exec -i "$K8S_OBJECT" -- tar -xf - -C /bin/
 fi
 
-exec kubectl "${namespace[@]}" exec -i "$K8S_OBJECT" -- "$@"
+exec kubectl "${namespace_args[@]}" exec -i "$K8S_OBJECT" -- "$@"
 


### PR DESCRIPTION
Fixes #209

### Problem

The [shellcheck PR](#206) [quoted `$namespace` in syncback's krsync.sh](https://github.com/tilt-dev/tilt-extensions/commit/018a67d9a544f9f1df6238074db9e781ef7af60b#diff-1735f7dcd2160cebc05a56e9882d2092d4725f9b8104ea5a22e7b81e7fb85864L43). It turns out `$namespace` is not a namespace but either `''` or `'-n some_namespace'`. Quoting the latter breaks the script, yielding this error:
```
error: pod, type/name or --filename must be specified
```

### Solution

Use the syntax described in the [exceptions section for SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086#exceptions).

I skimmed the [shellcheck PR](#206) and didn't see any other instances of this issue.