### PR TITLE
git_resource: add Windows support

### DIFF
--- a/git_resource/Tiltfile
+++ b/git_resource/Tiltfile
@@ -136,7 +136,7 @@ def _parse_repository_url(url):
     if is_ssh:
         url = 'git@' + url
 
-    repository_name = str(local('basename %s .git' % url, quiet=True)).strip()
+    repository_name = os.path.basename(url).rstrip('.git')
 
     return url, repository_name, tree
 

--- a/git_resource/test/Tiltfile
+++ b/git_resource/test/Tiltfile
@@ -41,6 +41,21 @@ url_test_cases = [
         tree='@myRevisionSha'),
 ]
 
+if os.name == 'nt':
+    url_test_cases.append(
+      _case(input='C:\\Path\\To\\repo',
+            url='C:\\Path\\To\\repo',
+            repo='repo',
+            tree=''),
+    )
+else:
+  url_test_cases.append(
+    _case(input='/path/to/repo',
+          url='/path/to/repo',
+          repo='repo',
+          tree=''),
+  )
+
 for case in url_test_cases:
   (url, expected) = case
   parse_repository_url = symbols['_parse_repository_url']


### PR DESCRIPTION
Replace `local('basename ...') with `os.path.basename()` so that
it's portable across platforms without needing GNU coreutils.

Fixes #211.