### PR TITLE
workflow: fix shellcheck violation

### DIFF
--- a/workflow/exec_workflow.sh
+++ b/workflow/exec_workflow.sh
@@ -21,5 +21,5 @@ if [[ "$WORKFLOW_INDEX" -eq "0" ]] ; then
 	exit 0
 fi
 
-$(head -n "$WORKFLOW_INDEX" "$cmdsfile" | tail -n 1)
-
+cmd=$(head -n "${WORKFLOW_INDEX}" "${cmdsfile}" | tail -n 1)
+eval "${cmd}"


### PR DESCRIPTION
Use `eval` on the command that is grabbed from the list of commands.

NOTE: The current approach actually has issues with multiline commands;
this is neither fixed nor exacerbated by this change - this is purely
to make shellcheck happy.