### PR TITLE
ci: make shellcheck violations visible in GitHub UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   shellcheck: circleci/shellcheck@2.2.4
 jobs:
-  check:
+  validate:
     docker:
       - image: tiltdev/tilt-extensions-ci@sha256:1fef97113de8538066e67d220367d953056993aca333382aca1e91b35c907bf4
 
@@ -26,5 +26,5 @@ workflows:
   build:
     jobs:
       - shellcheck/check
-      - check
+      - validate
       - test


### PR DESCRIPTION
Something between GitHub and CircleCI means the jobs were just
getting considered by the final part of the name, so `check` (our
custom Tilt extensions validation) and `shellcheck/check` (from
the orb) were clobbering each other - GitHub would only show
2 checks (there are 3) and so shellcheck failures could be
hidden.

Easy fix here is to just rename one of the jobs 🤷