### PR TITLE
Accept all local args in local_output

### DIFF
--- a/local_output/Tiltfile
+++ b/local_output/Tiltfile
@@ -1,2 +1,2 @@
-def local_output(command):
-  return str(local(command)).rstrip('\n')
+def local_output(command, quiet=False, command_bat='', echo_off=False, env={}, dir=''):
+  return str(local(command, quiet=quiet, command_bat=command_bat, echo_off=echo_off, env=env, dir=dir)).rstrip('\n')


### PR DESCRIPTION
This extension is super handy for grabbing the output of commands, but it doesn't have argument parity with the builtin `local`. It's often super handy to be able to pass in a new env var or set `quiet`, this PR adds the same default args as `local` and passes them through