### PR TITLE
restart_process: Create restart-wrapper container image with custom entr args

### DIFF
--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -29,7 +29,7 @@ def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, t
     # declare a new docker build that adds a static binary of tilt-restart-wrapper
     # (which makes use of `entr` to watch files and restart processes) to the user's image
     df = '''
-    FROM tiltdev/restart-helper:2020-10-16 as restart-helper
+    FROM tiltdev/restart-helper:2021-08-09 as restart-helper
 
     FROM {}
     RUN ["touch", "{}"]

--- a/restart_process/test/test-docker.sh
+++ b/restart_process/test/test-docker.sh
@@ -22,6 +22,8 @@ fi
 grep -q "Are you there, pod?" tilt.log
 GREP_EXIT=$?
 
+cat tilt.log
+
 rm tilt.log
 
 exit $GREP_EXIT

--- a/restart_process/tilt-restart-wrapper.go
+++ b/restart_process/tilt-restart-wrapper.go
@@ -41,11 +41,12 @@ import (
 
 var watchFile = flag.String("watch_file", "/.restart-proc", "File that entr will watch for changes; changes to this file trigger `entr` to rerun the command(s) passed")
 var entrPath = flag.String("entr_path", "/entr", "Path to `entr` executable")
+var entrFlags = flag.String("entr_flags", "-rz", "Command line flags to pass to `entr` executable")
 
 func main() {
 	flag.Parse()
 
-	cmd := exec.Command(*entrPath, "-rz")
+	cmd := exec.Command(*entrPath, *entrFlags)
 	cmd.Stdin = strings.NewReader(fmt.Sprintf("%s\n", *watchFile))
 	cmd.Args = append(cmd.Args, flag.Args()...)
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/restart2:

cdeceebc29b3ac66cf6e448d63ff2dbe78427cf4 (2021-08-09 16:52:25 -0400)
restart_process: Create restart-wrapper container image with custom entr args

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics