### PR TITLE
local_output: fix empty serve_cmd

### DIFF
--- a/local_output/Tiltfile
+++ b/local_output/Tiltfile
@@ -1,2 +1,2 @@
-def local_output(command, quiet=False, command_bat='', echo_off=False, env={}, dir=''):
-  return str(local(command, quiet=quiet, command_bat=command_bat, echo_off=echo_off, env=env, dir=dir)).rstrip('\n')
+def local_output(*args, **kwargs):
+  return str(local(*args, **kwargs)).rstrip('\n')

--- a/local_output/test/Tiltfile
+++ b/local_output/test/Tiltfile
@@ -1,0 +1,9 @@
+load('../Tiltfile', 'local_output')
+
+s = local_output('echo abc')
+s += local_output('echo def')
+
+print(s)
+
+# since tilt ci requires a resource
+local_resource('dummy', 'echo dummy')

--- a/local_output/test/test.sh
+++ b/local_output/test/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cd "$(dirname "$0")" || exit
+
+set -euo pipefail
+
+OUTPUT="$(tilt ci)"
+
+if ! (echo "$OUTPUT" | grep -q abcdef); then
+  echo "did not find string 'abcdef' in output"
+  echo "output:"
+  echo
+  echo "$OUTPUT"
+  exit 1
+fi


### PR DESCRIPTION
### Problem

#217 defaulted command_bat to the empty string, which can cause seg faults (#4842)

Also, explicitly listing all the `local` args is error-prone and needs maintenance

### Solution

Just forward all the args from `local_output` to `local`