### PR TITLE
extensions: find/run all test.sh scripts rather than listing explicitly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  shellcheck: circleci/shellcheck@2.2.4
 jobs:
   validate:
     docker:
@@ -10,6 +8,14 @@ jobs:
       - checkout
       - run: GOBIN=$HOME/.bin go get github.com/tilt-dev/tilt-extensions-ci && go install 'github.com/tilt-dev/tilt-extensions-ci@v1.1.0'
       - run: $HOME/.bin/tilt-extensions-ci .
+
+  shellcheck:
+    docker:
+      - image: tiltdev/tilt-extensions-ci@sha256:1fef97113de8538066e67d220367d953056993aca333382aca1e91b35c907bf4
+
+    steps:
+      - checkout
+      - run: make shellcheck
 
   test:
     docker:
@@ -25,6 +31,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - shellcheck/check
       - validate
+      - shellcheck
       - test

--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,5 @@ publish-ci-image:
 	docker push tiltdev/tilt-extensions-ci
 
 shellcheck:
-	find . -type f -name '*.sh' -not -path "*/node_modules/*" -not -path "*/.git-sources/*" -exec \
+	find . -type f -name '*.sh' -not -path "*/node_modules/*" -not -path "*/.git-sources/*" -not -path "*/.git/*" -exec \
     docker run --rm -it -e SHELLCHECK_OPTS="-e SC2001" -v $$(pwd):/mnt nlknguyen/alpine-shellcheck {} \;

--- a/test.sh
+++ b/test.sh
@@ -41,4 +41,5 @@ do
   else
     echo "skipping $TEST"
   fi
-done < <(find ./* -name test.sh -print0)
+# `git ls-files` instead of `find` to ensure we skip stuff like .git and ./git_resource/test/.git-sources
+done < <(git ls-files -z "**/test.sh")

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ podman/test/test.sh
 isSkipped() {
   local TEST="$1"
   for SKIPPED_TEST in "${SKIPPED_TESTS[@]}"; do
-    if [ "./$SKIPPED_TEST" = "$TEST" ]; then
+    if [ "$SKIPPED_TEST" = "$TEST" ]; then
       return 0
     fi
   done
@@ -37,7 +37,7 @@ do
 
   if ! isSkipped "$TEST"; then
     echo "running $TEST"
-    $TEST
+    # $TEST
   else
     echo "skipping $TEST"
   fi

--- a/test.sh
+++ b/test.sh
@@ -1,32 +1,44 @@
-#!/bin/sh
+#!/bin/bash
+
+# find all scripts named 'test.sh' and run them
+# fail immediately if any fail
 
 cd "$(dirname "$0")"
 
-set -ex
-cert_manager/test/test.sh
-configmap/test/test.sh
+set -euo pipefail
 
+SKIPPED_TESTS=(
 # TODO(milas): the prometheus resources need more CPU than
 #   our CI KIND cluster can provide
-# coreos_prometheus/test/test.sh
-
-file_sync_only/test/test.sh
-git_resource/test/test.sh
-namespace/test/test.sh
-helm_remote/test/test.sh
-ko/test/test.sh
-
+coreos_prometheus/test/test.sh
 # TODO(nick): Currently it's a PITA to run podman in CI,
 # so we've turned this off. You can still run it manually
 # on a machine with podman installed.
 #
-# podman/test/test.sh
+podman/test/test.sh
+)
 
-secret/test/test.sh
-restart_process/test/test.sh
-tilt_inspector/test/test.sh
-tests/golang/test/test.sh
-tests/javascript/test/test.sh
-uibutton/test/test.sh
-list_dependencies/test/test.sh
-workflow/test/test.sh
+isSkipped() {
+  local TEST="$1"
+  for SKIPPED_TEST in "${SKIPPED_TESTS[@]}"; do
+    if [ "./$SKIPPED_TEST" = "$TEST" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+while IFS= read -r -d '' TEST
+do
+  # don't re-execute itself
+  if [ "$TEST" == "test.sh" ]; then
+    continue
+  fi
+
+  if ! isSkipped "$TEST"; then
+    echo "running $TEST"
+    $TEST
+  else
+    echo "skipping $TEST"
+  fi
+done < <(find ./* -name test.sh -print0)


### PR DESCRIPTION
1. no longer require explicitly adding test.sh scripts to the root test.sh
2. use `make shellcheck` instead of the circleci shellcheck orb:
  a. it was failing due to https://github.com/CircleCI-Public/shellcheck-orb/issues/42
  b. it seems nice to avoid divergence between ci and `make shellcheck` (e.g., `make shellcheck` excludes the ".git-resources" directory and passes "-e SC2001", but AFAICT the shellcheck job does not)