### PR TITLE
workflow: quality of life tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 */test/.tilt-cache
 */test/.build
 */test/tilt_modules
+
+workflow_*.tmp

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -7,23 +7,27 @@ workflow(workflow_name : string, resource_name : string, work_cmds=[[]] : [[stri
 ```
 Where `work_cmds` is an array of argv, and `clear_cmd` is a single argv. For example:
 ```
+load('ext://workflow', 'workflow')
+
 workflow(
 	'my-workflow',
-	'my-resource',
-	[ ['echo', '1st'], ['echo', '2nd'], ['echo', '3rd'] ],
-	['echo', 'resetting...'],
+	resource_name='my-resource',
+	work_cmds=[ ['echo', '1st'], ['echo', '2nd'], ['echo', '3rd'] ],
+	clear_cmd=['echo', 'resetting...'],
 )
 ```
 
 Each invocation of `workflow` creates a set of three buttons in the tilt UI:
-* `play`: run the next command.
-* `replay`: re-run the last command.
-* `rewind`: run the reset command and start the workflow over.
+* `Next Step`: run the next command.
+* `Re-run Step`: re-run the last command.
+* `Reset`: run the reset command and start the workflow over.
 
-Command outputs are shown in the Tilt UI.
+Command outputs are shown in the Tilt UI in the associated resource's log view.
 
 All button IDs and temporary file names contain the workflow name and resource name.
-This makes it possbile for multiple workflows to be attached to the same resource,
+This makes it possible for multiple workflows to be attached to the same resource,
 and for workflows with the same name to exist on different resources.
 
-
+By default, workflow state files will be stored inside the `tilt_modules/workflow`
+directory along with the extension. If you check your `tilt_modules/` directory into
+source control, add `workflow_*.tmp` to your `.gitignore` or equivalent.

--- a/workflow/Tiltfile
+++ b/workflow/Tiltfile
@@ -19,7 +19,12 @@ def workflow(workflow_name, resource_name, work_cmds=[[]], clear_cmd=[]):
     set_work_cmds(workflow_name, resource_name, work_cmds)
     set_clear_cmd(workflow_name, resource_name, clear_cmd)
 
-    local([ os.path.join(cwd, 'write_index.sh'), workflow_name, resource_name, '0' ], echo_off=True)
+    # only reset the workflow on initial load
+    # TODO(milas): using a Tilt ConfigMap would be a better solution
+    workflow_init_key = 'TILT_WORKFLOW_INIT_{}'.format(workflow_name.lower())
+    if not os.getenv(workflow_init_key):
+        local([ os.path.join(cwd, 'write_index.sh'), workflow_name, resource_name, '0' ], echo_off=True)
+        os.putenv(workflow_init_key, '1')
 
     cmd_button(
         name = '%s-%s-play' % (workflow_name, resource_name),

--- a/workflow/Tiltfile
+++ b/workflow/Tiltfile
@@ -24,7 +24,7 @@ def workflow(workflow_name, resource_name, work_cmds=[[]], clear_cmd=[]):
     cmd_button(
         name = '%s-%s-play' % (workflow_name, resource_name),
         resource = resource_name,
-        text = '%s-play' % (workflow_name),
+        text = '%s: Next Step' % (workflow_name),
         argv = [ os.path.join(cwd, 'play.sh'), workflow_name, resource_name ],
         icon_name = 'play_arrow',
     )
@@ -32,7 +32,7 @@ def workflow(workflow_name, resource_name, work_cmds=[[]], clear_cmd=[]):
     cmd_button(
         name = '%s-%s-replay' % (workflow_name, resource_name),
         resource = resource_name,
-        text = '%s-replay' % (workflow_name),
+        text = '%s: Re-run Step' % (workflow_name),
         argv = [ os.path.join(cwd, 'replay.sh'), workflow_name, resource_name ],
         icon_name = 'replay',
     )
@@ -40,7 +40,7 @@ def workflow(workflow_name, resource_name, work_cmds=[[]], clear_cmd=[]):
     cmd_button(
         name = '%s-%s-rewind' % (workflow_name, resource_name),
         resource = resource_name,
-        text = '%s-rewind' % (workflow_name),
+        text = '%s: Reset' % (workflow_name),
         argv = [ os.path.join(cwd, 'rewind.sh'), workflow_name, resource_name ],
         icon_name = 'fast_rewind',
     )

--- a/workflow/Tiltfile
+++ b/workflow/Tiltfile
@@ -16,33 +16,31 @@ def set_clear_cmd(flow_name, res_name, clear_cmd):
     local(cmd, echo_off=True)
 
 def workflow(workflow_name, resource_name, work_cmds=[[]], clear_cmd=[]):
+    set_work_cmds(workflow_name, resource_name, work_cmds)
+    set_clear_cmd(workflow_name, resource_name, clear_cmd)
 
-	set_work_cmds(workflow_name, resource_name, work_cmds)
-	set_clear_cmd(workflow_name, resource_name, clear_cmd)
+    local([ os.path.join(cwd, 'write_index.sh'), workflow_name, resource_name, '0' ], echo_off=True)
 
-	local([ os.path.join(cwd, 'write_index.sh'), workflow_name, resource_name, '0' ], echo_off=True)
+    cmd_button(
+        name = '%s-%s-play' % (workflow_name, resource_name),
+        resource = resource_name,
+        text = '%s-play' % (workflow_name),
+        argv = [ os.path.join(cwd, 'play.sh'), workflow_name, resource_name ],
+        icon_name = 'play_arrow',
+    )
 
-	cmd_button(
-		name = '%s-%s-play' % (workflow_name, resource_name),
-		resource = resource_name,
-		text = '%s-play' % (workflow_name),
-		argv = [ os.path.join(cwd, 'play.sh'), workflow_name, resource_name ],
-		icon_name = 'play_arrow',
-	)
+    cmd_button(
+        name = '%s-%s-replay' % (workflow_name, resource_name),
+        resource = resource_name,
+        text = '%s-replay' % (workflow_name),
+        argv = [ os.path.join(cwd, 'replay.sh'), workflow_name, resource_name ],
+        icon_name = 'replay',
+    )
 
-	cmd_button(
-		name = '%s-%s-replay' % (workflow_name, resource_name),
-		resource = resource_name,
-		text = '%s-replay' % (workflow_name),
-		argv = [ os.path.join(cwd, 'replay.sh'), workflow_name, resource_name ],
-		icon_name = 'replay',
-	)
-
-	cmd_button(
-		name = '%s-%s-rewind' % (workflow_name, resource_name), 
-		resource = resource_name,
-		text = '%s-rewind' % (workflow_name),
-		argv = [ os.path.join(cwd, 'rewind.sh'), workflow_name, resource_name ],
-		icon_name = 'fast_rewind',
-	)
-
+    cmd_button(
+        name = '%s-%s-rewind' % (workflow_name, resource_name),
+        resource = resource_name,
+        text = '%s-rewind' % (workflow_name),
+        argv = [ os.path.join(cwd, 'rewind.sh'), workflow_name, resource_name ],
+        icon_name = 'fast_rewind',
+    )

--- a/workflow/exec_reset.sh
+++ b/workflow/exec_reset.sh
@@ -11,8 +11,10 @@ fi
 resource_name=$1
 workflow_name=$2
 
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+state_dir="${TILT_WORKFLOW_STATE_PATH:-$script_dir}"
+
 while read -r CMD_LINE
 do
 	$CMD_LINE
-done < "reset_cmds-$resource_name-$workflow_name.tmp"
-
+done < "${state_dir}/workflow_reset_cmds-$resource_name-$workflow_name.tmp"

--- a/workflow/exec_workflow.sh
+++ b/workflow/exec_workflow.sh
@@ -11,8 +11,11 @@ fi
 resource_name=$1
 workflow_name=$2
 
-indexfile="workflow_index-$resource_name-$workflow_name.tmp"
-cmdsfile="workflow_cmds-$resource_name-$workflow_name.tmp"
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+state_dir="${TILT_WORKFLOW_STATE_PATH:-$script_dir}"
+
+indexfile="${state_dir}/workflow_index-$resource_name-$workflow_name.tmp"
+cmdsfile="${state_dir}/workflow_cmds-$resource_name-$workflow_name.tmp"
 
 WORKFLOW_INDEX=$(head -n 1 <"$indexfile")
 

--- a/workflow/increment_index.sh
+++ b/workflow/increment_index.sh
@@ -11,8 +11,11 @@ fi
 resource_name=$1
 workflow_name=$2
 
-indexfile="workflow_index-$resource_name-$workflow_name.tmp"
-cmdsfile="workflow_cmds-$resource_name-$workflow_name.tmp"
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+state_dir="${TILT_WORKFLOW_STATE_PATH:-$script_dir}"
+
+indexfile="${state_dir}/workflow_index-$resource_name-$workflow_name.tmp"
+cmdsfile="${state_dir}/workflow_cmds-$resource_name-$workflow_name.tmp"
 
 num_cmds=$(wc -l "$cmdsfile" | cut -f 8 -d ' ')
 i=$(cat "$indexfile")
@@ -22,4 +25,3 @@ if [ "$i" -gt "$num_cmds" ] ; then
 fi
 
 echo "$i" > "$indexfile"
-

--- a/workflow/write_index.sh
+++ b/workflow/write_index.sh
@@ -12,7 +12,9 @@ resource_name=$1
 workflow_name=$2
 index=$3
 
-indexfile="workflow_index-$resource_name-$workflow_name.tmp"
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+state_dir="${TILT_WORKFLOW_STATE_PATH:-$script_dir}"
+
+indexfile="${state_dir}/workflow_index-$resource_name-$workflow_name.tmp"
 
 echo "$index" > "$indexfile"
-

--- a/workflow/write_reset.sh
+++ b/workflow/write_reset.sh
@@ -11,7 +11,10 @@ fi
 resource_name=$1
 workflow_name=$2
 
-resetfile="reset_cmds-$resource_name-$workflow_name.tmp"
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+state_dir="${TILT_WORKFLOW_STATE_PATH:-$script_dir}"
+
+resetfile="${state_dir}/workflow_reset_cmds-$resource_name-$workflow_name.tmp"
 
 rm -f "$resetfile"
 shift 2
@@ -19,4 +22,3 @@ for i in "$@"
 do
 	echo "$i" >> "$resetfile"
 done
-

--- a/workflow/write_workflow.sh
+++ b/workflow/write_workflow.sh
@@ -11,7 +11,10 @@ fi
 resource_name=$1
 workflow_name=$2
 
-cmdfile="workflow_cmds-$resource_name-$workflow_name.tmp"
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+state_dir="${TILT_WORKFLOW_STATE_PATH:-$script_dir}"
+
+cmdfile="${state_dir}/workflow_cmds-$resource_name-$workflow_name.tmp"
 
 rm -f "$cmdfile"
 shift 2
@@ -19,4 +22,3 @@ for i in "$@"
 do
 	echo "$i" >> "$cmdfile"
 done
-


### PR DESCRIPTION
Some miscellaneous changes based on (small) hiccups I encountered when using this for the workshop.

I bundled these together just because it was easier and they are pretty small tweaks.

* adjust button labels to be a bit more user friendly / "pretty"
* only reset progress on initial load
  * realized whenever you make a change to `Tiltfile` or any other "config" files, it'd reset you back to beginning
* store temporary files in the `tilt_modules/workflow` directory to avoid creating a bunch of temp files in the repo root
  * undocumented `TILT_WORKFLOW_STATE_PATH` env var can allow setting a custom directory (e.g. tmpdir)
* make sure all temp files meet pattern `workflow_*.tmp` to make it easy to `.gitignore` them
  * see above: hopefully most people already ignore `tilt_modules/` so won't need to, but in the event they do, this makes it easy