### PR TITLE
kubefwd: add a refresh button to restart kubefwd without sudo

### DIFF
--- a/kubefwd/README.md
+++ b/kubefwd/README.md
@@ -15,6 +15,8 @@ https://kubefwd.com/
 
 - `bash`
 - `kubefwd`
+- `entr`
+- GNU core utils (`tr`, `sort`) - `brew install coreutils`
 
 ## Usage
 
@@ -27,9 +29,25 @@ v1alpha1.extension(name='kubefwd:config', repo_name='default', repo_path='kubefw
 
 When Tilt starts up for the first time, 
 it will prompt up your native OS GUI for your sudo password.
-Only `kubefwd` will get the `sudo` privileges.
+Only `kubefwd` and its operator will get the `sudo` privileges.
 
 ## Future Work
+
+### Pod Discovery
+
+If a pod inside the cluster restarts, you need to reboot `kubefwd`.  You can do
+this manually from the tilt UI (the refresh button) or from the CLI with `tilt
+trigger kubefwd:run`.  Could we do something more automatic?
+
+Possible solutions:
+
+1) A system that watches the Tilt `KubernetesDiscovery` API and
+  restarts it for you whenever the pods change.
+  
+2) Even better, a version of `kubefwd` that reads the pods from the Tilt API.
+
+Currently, this extension uses `entr` to restart `kubefwd`
+without requesting new credentials.
 
 ### Namespaces
 
@@ -38,15 +56,20 @@ Currently, kubefwd only works for the `default` namespace.
 In a follow-up PR, I want to add a controller that auto-configures kubefwd
 for whatever namespaces you're deploying to.
 
-### Pod Discovery
+### Kubefwd without deploys
 
-If a pod inside the cluster restarts, you need to reboot `kubefwd`.  You can do
-this manually from the tilt UI (the refresh button) or from the CLI with `tilt
-trigger kubefwd`.  Could we do something more automatic?
+The default mode of this extension is going to be to run kubefwd for namespaces
+where you're deploying.
 
-Possible solutions:
+In the future, we'd like to be able to support kubefwd for manually-configured namespaces.
 
-1) A system that watches the Tilt `KubernetesDiscovery` API and
-  restarts it for you whenever the pods change.
-  
-2) Even better, a version of `kubefwd` that reads the pods from the Tilt API.
+For example, you might be running `kubefwd` against a read-only cluster,
+and only running local services for editing.
+
+### Multi-cluster kubefwd
+
+Long-term, we'd like to be able to run kubefwd against multiple clusters at once
+(e.g., a read-only staging cluster and a writable dev cluster and a local KIND
+cluster.)
+
+

--- a/kubefwd/Tiltfile
+++ b/kubefwd/Tiltfile
@@ -1,4 +1,11 @@
+trigger_file = str(local('mktemp --suffix -tilt-kubefwd')).strip()
+local(['chmod', 'a+rw', trigger_file], quiet=True)
+
+# Creates a button that refreshes the kubefwd without
+# requiring new credentials.
+local(['./create-refresh-button.sh', trigger_file])
+
 local_resource(
   name='kubefwd:run',
-  serve_cmd='./sudo-kubefwd.sh',
+  serve_cmd=['./sudo-kubefwd.sh', trigger_file],
   deps=['sudo-kubefwd.sh', 'run-kubefwd.sh'])

--- a/kubefwd/create-refresh-button.sh
+++ b/kubefwd/create-refresh-button.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TRIGGER="$1"
+
+cat <<EOF | tilt apply -f -
+apiVersion: tilt.dev/v1alpha1
+kind: UIButton
+metadata:
+  name: kubefwd:refresh
+spec:
+  text: Refresh
+  location:
+    componentType: resource
+    componentID: kubefwd:run
+---
+apiVersion: tilt.dev/v1alpha1
+kind: Cmd
+metadata:
+  name: kubefwd:refresh
+  annotations:
+    "tilt.dev/resource": "kubefwd:run"
+spec:
+  args: ["touch", "$TRIGGER"]
+  startOn:
+    uiButtons:
+    - kubefwd:refresh
+EOF

--- a/kubefwd/run-kubefwd.sh
+++ b/kubefwd/run-kubefwd.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 # Run kubefwd, assuming we already have sudo privs.
 
-set -exuo pipefail
-
 KUBEFWD="$1"
 export KUBECONFIG="$2"
+ENTR="$3"
+TRIGGER="$4"
 
-"$KUBEFWD" svc -n default
+set -exuo pipefail
+
+echo "$TRIGGER" | "$ENTR" -rn "$KUBEFWD" svc -n default

--- a/kubefwd/sudo-kubefwd.sh
+++ b/kubefwd/sudo-kubefwd.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
+#
+# Runs kubefwd with admin privileges.
+# Invokes an OS-specific sudo UI.
 
+TRIGGER="$1"
+ENTR=$(command -v entr)
 OSASCRIPT=$(command -v osascript)
 PKEXEC=$(command -v pkexec)
 KDESUDO=$(command -v kdesudo)
@@ -16,27 +21,33 @@ if [[ "$KUBEFWD" == "" ]]; then
     exit 1
 fi
 
+if [[ "$ENTR" == "" ]]; then
+    echo "entr not found. Did you forget to install it?"
+    echo "Run: brew install entr"
+    exit 1
+fi
+
 if [[ "$OSASCRIPT" != "" ]]; then
     set -x
-    "$OSASCRIPT" -e "do shell script \"$RUN_KUBEFWD $KUBEFWD $KUBECONFIG\" with administrator privileges"
+    "$OSASCRIPT" -e "do shell script \"$RUN_KUBEFWD $KUBEFWD $KUBECONFIG $ENTR $TRIGGER\" with administrator privileges"
     exit "$?"
 fi
 
 if [[ "$PKEXEC" != "" ]]; then
     set -x
-    "$PKEXEC" --disable-internal-agent "$RUN_KUBEFWD" "$KUBEFWD" "$KUBECONFIG"
+    "$PKEXEC" --disable-internal-agent "$RUN_KUBEFWD" "$KUBEFWD" "$KUBECONFIG" "$ENTR" "$TRIGGER"
     exit "$?"
 fi 
 
 if [[ "$KDESUDO" != "" ]]; then
     set -x
-    "$KDESUDO" --comment 'Tilt needs admin privs to run kubefwd. Please enter your password.' "$RUN_KUBEFWD" "$KUBEFWD"  "$KUBECONFIG"
+    "$KDESUDO" --comment 'Tilt needs admin privs to run kubefwd. Please enter your password.' "$RUN_KUBEFWD" "$KUBEFWD"  "$KUBECONFIG" "$ENTR" "$TRIGGER"
     exit "$?"
 fi 
 
 if [[ "$GKSUDO" != "" ]]; then
     set -x
-    "$GKSUDO" --preserve-env --sudo-mode --description 'tilt/kubefwd' "$RUN_KUBEFWD" "$KUBEFWD" "$KUBECONFIG"
+    "$GKSUDO" --preserve-env --sudo-mode --description 'tilt/kubefwd' "$RUN_KUBEFWD" "$KUBEFWD" "$KUBECONFIG" "$ENTR" "$TRIGGER"
     exit "$?"
 fi 
 


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/kubefwd2:

91cbb2b65d65a1f0e82e38b80d5d7fef5be062ba (2021-08-24 15:42:30 -0400)
kubefwd: add a refresh button to restart kubefwd without sudo

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics