### PR TITLE
secret: function to generate secret config from a map

### DIFF
--- a/secret/Tiltfile
+++ b/secret/Tiltfile
@@ -59,6 +59,36 @@ def secret_yaml_generic(name, namespace="", from_file=None, secret_type=None, fr
   args.extend(["-o=yaml", "--dry-run=client"])
   return local(args)
 
+def secret_from_dict(name, namespace="", inputs={}):
+    """Returns YAML for a generic secret
+    Args:
+        name: The configmap name.
+        namespace: The namespace.
+        inputs: A dict of keys and values to use. Nesting is not supported
+    Returns:
+        The secret YAML as a blob
+    """
+
+    args = [
+        "kubectl",
+        "create",
+        "secret",
+        "generic",
+        name,
+    ]
+
+    if namespace:
+        args.extend(["-n", namespace])
+
+    if type(inputs) != "dict":
+        fail("Bad argument to secret_from_dict, inputs was not dict typed")
+
+    for k,v in inputs.items():
+        args.extend(["--from-literal", "%s=%s" % (k,v)])
+
+    args.extend(["-o=yaml", "--dry-run=client"])
+    return local(args, quiet=True)
+
 def secret_create_generic(name, namespace="", from_file=None, secret_type=None, from_env_file=None):
   """Creates a secret in the current Kubernetes cluster.
 

--- a/secret/test/Tiltfile
+++ b/secret/test/Tiltfile
@@ -1,4 +1,7 @@
-load('../Tiltfile', 'secret_create_generic')
+load('../Tiltfile', 'secret_create_generic', 'secret_from_dict')
 
+k8s_yaml(secret_from_dict("secrets", inputs = {
+    'SOME_TOKEN' : os.getenv('SOME_TOKEN')
+}))
 secret_create_generic('pgpass', namespace='default', from_file='.pgpass=./.pgpass')
 k8s_yaml('job.yaml')

--- a/secret/test/job.yaml
+++ b/secret/test/job.yaml
@@ -7,6 +7,15 @@ spec:
   template:
     spec:
       containers:
+      - name: secret-verify-dict
+        image: alpine
+        command: [ "/bin/echo", "$(SOME_TOKEN)" ]
+        env:
+          - name: TEST_VAR
+            valueFrom:
+              secretKeyRef:
+                name: secrets
+                key: SOME_TOKEN
       - name: secret-verify
         image: alpine
         command: ["grep", "password", "/var/secrets/pgpass/.pgpass"]

--- a/secret/test/test.sh
+++ b/secret/test/test.sh
@@ -2,6 +2,8 @@
 
 cd "$(dirname "$0")"
 
+export SOME_TOKEN=abc123
+
 set -ex
 tilt ci
 tilt down --delete-namespaces


### PR DESCRIPTION
I am currently using Tilt to develop configuration for backstage.
Backstage required Gihtub credentials so I ended up with this;
```
k8s_yaml(secret_from_dict("github", inputs = {
    'AUTH_GITHUB_CLIENT_ID'     : os.getenv("AUTH_GITHUB_CLIENT_ID"),
    'AUTH_GITHUB_CLIENT_SECRET' : os.getenv("AUTH_GITHUB_CLIENT_SECRET")
}))
```
and the proposed function based on the `configmap` extension,