### PR TITLE
Maintain LF line-endings for shell scripts on Windows systems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Maintain LF line-endings for shell scripts on Windows systems.
+*.sh text eol=lf


### PR DESCRIPTION
CRLF line-endings break the ability to execute shell scripts on Windows. This will allow extensions that rely on shell scripts (like Syncback) greater compatibility with Windows/WSL.
