### PR TITLE
secret: add secret_from_dict to the readme

### DIFF
--- a/secret/README.md
+++ b/secret/README.md
@@ -30,6 +30,16 @@ load('ext://secret', 'secret_yaml_generic')
 k8s_yaml(secret_yaml_generic('name', from_file=[...]))
 ```
 
+### secret_from_dict
+
+```
+secret_from_dict(name: str, namespace: str = "", inputs = None): blob
+```
+
+Returns YAML for a secret from a dictionary.
+
+* `inputs` ( dict) - A dict of keys and values to use. Nesting is not supported
+
 ## Example Usage
 
 ### For a Postgres password:
@@ -42,8 +52,17 @@ secret_create_generic('pgpass', from_file='.pgpass=./.pgpass')
 ### For Google Cloud Platform Key:
 
 ```
-load('ext://secret', 'secret_generic_create')
+load('ext://secret', 'secret_create_generic')
 secret_create_generic('gcp-key', from_file='key.json=./gcp-creds.json')
+```
+
+### From a dict:
+
+```
+load('ext://secret', 'secret_from_dict')
+k8s_yaml(secret_from_dict("secrets", inputs = {
+    'SOME_TOKEN' : os.getenv('SOME_TOKEN')
+}))
 ```
 
 ## Caveats


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/readme:

2741af7da2c24d6c9e399d4a1833cfd0489b727d (2021-09-02 17:04:10 -0400)
secret: add secret_from_dict to the readme

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics