### PR TITLE
kubefwd: add the ability to kubefwd a namespace we don't deploy to

### DIFF
--- a/kubefwd/README.md
+++ b/kubefwd/README.md
@@ -18,14 +18,21 @@ https://kubefwd.com/
 - `entr`
 - GNU core utils (`tr`, `sort`) - `brew install coreutils`
 
-## Usage
-
-Add these lines to your Tiltfile:
+## Examples
 
 ```python
+# kubefwd all namespaces Tilt deploys to.
 v1alpha1.extension_repo(name='default', url='https://github.com/tilt-dev/tilt-extensions')
 v1alpha1.extension(name='kubefwd:config', repo_name='default', repo_path='kubefwd')
 ```
+
+```python
+# kubefwd all namespaces Tilt deploys to + manually configured additional namespace 'kubesystem'.
+v1alpha1.extension_repo(name='default', url='https://github.com/tilt-dev/tilt-extensions')
+v1alpha1.extension(name='kubefwd:config', repo_name='default', repo_path='kubefwd', args=['--namespaces=kubesystem'])
+```
+
+## Usage
 
 When Tilt starts up for the first time, it will prompt up your native OS GUI for
 your sudo password.  Only `kubefwd` and its operator will get the `sudo`
@@ -54,17 +61,6 @@ Possible solutions:
 
 Currently, this extension uses `entr` to restart `kubefwd`
 without requesting new credentials.
-
-### Kubefwd without deploys
-
-The default mode of this extension is to run kubefwd for namespaces
-where you're deploying.
-
-In the future, we'd like to be able to support kubefwd for manually-configured
-namespaces.
-
-For example, you might be running `kubefwd` against a read-only cluster,
-and only running local services for editing.
 
 ### Multi-cluster kubefwd
 

--- a/kubefwd/Tiltfile
+++ b/kubefwd/Tiltfile
@@ -1,3 +1,10 @@
+# Accept namespaces as args. This requires tilt > v0.22.7
+
+config.define_string_list("namespaces")
+cfg = config.parse()
+
+namespaces = cfg.get('namespaces', [])
+
 trigger_file = str(local('mktemp --suffix -tilt-kubefwd')).strip()
 
 # Creates a button that refreshes the kubefwd without
@@ -7,4 +14,5 @@ local(['./create-refresh-button.sh', trigger_file])
 local_resource(
   name='kubefwd:run',
   serve_cmd=['./sudo-kubefwd.sh', trigger_file],
-  deps=['sudo-kubefwd.sh', 'run-kubefwd.sh', 'run-kubefwd-internal.sh'])
+  deps=['sudo-kubefwd.sh', 'run-kubefwd.sh', 'run-kubefwd-internal.sh', 'watch-namespaces.sh'],
+  serve_env={'TILT_CFG_NAMESPACES': ' '.join(namespaces)})

--- a/kubefwd/watch-namespaces.sh
+++ b/kubefwd/watch-namespaces.sh
@@ -3,12 +3,18 @@
 # Continuously watch the namespaces that we're deploying to, and write them to
 # the trigger file.
 
-TRIGGER="$1"
+TRIGGER_FILE="$1"
+
+function reconcile {
+    NEW_NAMESPACES=$(tilt get kd -o=jsonpath='{.items[*].spec.watches[*].namespace}' | echo "$(cat -) $TILT_CFG_NAMESPACES" | tr -s ' ' '\n' | sort -u)
+    OLD_NAMESPACES=$(cat "$TRIGGER_FILE")
+    if [[ "$NEW_NAMESPACES" != "$OLD_NAMESPACES" ]]; then
+        echo "$NEW_NAMESPACES" > "$TRIGGER_FILE"
+    fi
+}
+
+reconcile
 
 tilt get kd --watch -o name | while read -r; do
-    NEW_NAMESPACES=$(tilt get kd -o=jsonpath='{.items[*].spec.watches[*].namespace}' | tr -s ' ' '\n' | sort -u)
-    OLD_NAMESPACES=$(cat "$TRIGGER")
-    if [[ "$NEW_NAMESPACES" != "$OLD_NAMESPACES" ]]; then
-        echo "$NEW_NAMESPACES" > "$TRIGGER"
-    fi
+    reconcile
 done


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/readonly:

11ef9ebde5038a71bd37c5eb3f58bd5355f09666 (2021-09-08 18:58:41 -0400)
kubefwd: add the ability to kubefwd a namespace we don't deploy to

2741af7da2c24d6c9e399d4a1833cfd0489b727d (2021-09-02 17:04:10 -0400)
secret: add secret_from_dict to the readme

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics