### PR TITLE
ngrok: add support for basic auth

### DIFF
--- a/ngrok/README.md
+++ b/ngrok/README.md
@@ -20,18 +20,31 @@ Every service with a link or port-forward will have a new button labelled 'ngrok
 Clicking the button will create a new tunnel. You can see all the currently
 open tunnels at http://localhost:4040/.
 
+## Flags
+
+`--auth=user:password`: Adds a basic auth prompt to all tunnels.
+
 ## Examples
+
+Default behavior:
 
 ```python
 v1alpha1.extension_repo(name='default', url='https://github.com/tilt-dev/tilt-extensions')
 v1alpha1.extension(name='ngrok:config', repo_name='default', repo_path='ngrok')
 ```
 
+With auth:
+
+```python
+v1alpha1.extension_repo(name='default', url='https://github.com/tilt-dev/tilt-extensions')
+v1alpha1.extension(
+  name='ngrok:config', 
+  repo_name='default', 
+  repo_path='ngrok', 
+  args=['--auth=user:password'])
+```
+
 ## Future Work
-
-### Authentication
-
-Add a way to add password authentication too all ngrok tunnels.
 
 ### Allowlist/blocklist
 

--- a/ngrok/README.md
+++ b/ngrok/README.md
@@ -22,7 +22,7 @@ open tunnels at http://localhost:4040/.
 
 ## Flags
 
-`--auth=user:password`: Adds a basic auth prompt to all tunnels.
+`--auth=my-user:my-password`: Adds a basic auth prompt to all tunnels.
 
 ## Examples
 
@@ -41,7 +41,19 @@ v1alpha1.extension(
   name='ngrok:config', 
   repo_name='default', 
   repo_path='ngrok', 
-  args=['--auth=user:password'])
+  args=['--auth=my-user:my-password'])
+```
+
+With auth from a file:
+
+```python
+password = str(read_file(os.path.join(os.getenv('HOME'), '.ngrok-password'))).strip()
+v1alpha1.extension_repo(name='default', url='https://github.com/tilt-dev/tilt-extensions')
+v1alpha1.extension(
+  name='ngrok:config', 
+  repo_name='default', 
+  repo_path='ngrok', 
+  args=['--auth=my-user:%s' % password])
 ```
 
 ## Future Work

--- a/ngrok/Tiltfile
+++ b/ngrok/Tiltfile
@@ -1,4 +1,8 @@
 
+config.define_string("auth")
+cfg = config.parse()
+
+auth = cfg.get('auth', '')
 config_file = str(local('mktemp --suffix -tilt-ngrok.yml')).strip()
 
 local_resource(
@@ -10,4 +14,5 @@ local_resource(
 local_resource(
   name='ngrok:operator',
   serve_cmd=['./ngrok-operator.sh', config_file],
+  serve_env={'TILT_NGROK_AUTH': auth},
   deps=['./ngrok-operator.sh'])

--- a/ngrok/ngrok-reconcile-config.sh
+++ b/ngrok/ngrok-reconcile-config.sh
@@ -6,12 +6,20 @@
 # 2) Gather all the enabled ports.
 # 3) Check to make sure the ngrok config is what we expect.
 
+auth_env="$TILT_NGROK_AUTH"
+
 set -euo pipefail
 
 config_file="$1"
 
 tunnels=()
 names="$(tilt get configmap -l tilt.dev/managed-by=tilt-extensions.ngrok -o name | sort -u)"
+auth=""
+if [[ "$auth_env" != "" ]]; then
+    auth="
+    auth: \"$auth_env\""
+fi
+
 for name in $names;
 do
     short=${name#configmap.tilt.dev/}
@@ -25,7 +33,7 @@ do
             tunnel="  \"$location:$port\":
     proto: http
     addr: $port
-    bind_tls: false"
+    bind_tls: false$auth"
             tunnels+=("$tunnel")
         done
     fi


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/password:

00e077c02543919865ba7374301d6e9669698ef4 (2021-09-10 20:08:45 -0400)
ngrok: add support for basic auth

dd96e9988399c4eb6e4b9b36f83069ee694ba35e (2021-09-10 18:35:45 -0400)
ngrok: add an ngrok operator

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics