### PR TITLE
kim: add extension to build images using kim.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`hello_world`](/hello_world): Print "Hello world!". Used in [Extensions](https://docs.tilt.dev/extensions.html).
 - [`helm_remote`](/helm_remote): Install a remote Helm chart (in a way that gets properly uninstalled when running `tilt down`)
 - [`jest_test_runner`](/jest_test_runner): Jest JavaScript test runner. Example from [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).
+- |`kim`](/kim): Use [kim](https://github.com/rancher/kim) to build images for Tilt
 - [`ko`](/ko): Use [Ko](https://github.com/google/ko) to build Go-based container images
 - [`kubebuilder`](/kubebuilder): Enable live-update for developing [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) projects.
 - [`kubectl_build`](/kubectl_build): Get faster build cycles and smaller disk usage by building docker images directly in the k8s cluster with [BuildKit CLI for kubectl](https://github.com/vmware-tanzu/buildkit-cli-for-kubectl).

--- a/kim/README.md
+++ b/kim/README.md
@@ -4,15 +4,20 @@ Author: [Lasse Højgaard](https://github.com/lhotrifork)
 
 Use kim (https://github.com/rancher/kim) to build images for Tilt.
 
+## Limitations
+As `kim build` will automatically push images onto kubernetes worker nodes this extension will not run `kim push`.
+
 ## Functions
 
-### `kim_build(ref: str, import_path: str, deps: List[str] = [])`
+### `kim_build(ref: str, import_path: str, deps: List[str] = [], ignore: str, extra_flags?: [str], **kwargs)`
 
 - **ref**: The name of the image to build. Must match the image
    name in the Kubernetes resources you're deploying.
-- **import_path**: A Go import path of the binary to build.
-- **deps**: A list of dependencies that can trigger rebuilds.
-
+- **context**: The build context of the image to build. Expressed as a file path.
+- **ignore**: Changes to the given files or directories do not trigger rebuilds.
+      Does not affect the build context.
+- **extra_flags**: Extra flags to pass to kim build.
+- **kwargs: will be passed to the underlying `custom_build` call
 ## Example Usage
 
 ```

--- a/kim/README.md
+++ b/kim/README.md
@@ -2,26 +2,23 @@
 
 Author: [Lasse Højgaard](https://github.com/lhotrifork)
 
-Use kim (https://github.com/rancher/kim) to build images for Tilt.
+Use [kim](https://github.com/rancher/kim) to build images for Tilt.
 
 ## Limitations
 As `kim build` will automatically push images onto kubernetes worker nodes this extension will not run `kim push`.
 
 ## Functions
-
-### `kim_build(ref: str, import_path: str, deps: List[str] = [], ignore: str, extra_flags?: [str], **kwargs)`
-
+### `kim_build(ref: str, context: str, ignore: List[str] = None, extra_flags: List[str]=None, **kwargs)`
 - **ref**: The name of the image to build. Must match the image
    name in the Kubernetes resources you're deploying.
 - **context**: The build context of the image to build. Expressed as a file path.
 - **ignore**: Changes to the given files or directories do not trigger rebuilds.
       Does not affect the build context.
-- **extra_flags**: Extra flags to pass to kim build.
-- **kwargs: will be passed to the underlying `custom_build` call
-## Example Usage
+- **extra_flags**: Extra flags to pass to kim build expressed as argv style array.
+- **kwargs**: will be passed to the underlying `custom_build` call
 
+## Example Usage
 ```
 load('ext://kim', 'kim_build')
 kim_build('hello-world-image', '.')
 ```
-

--- a/kim/README.md
+++ b/kim/README.md
@@ -1,0 +1,22 @@
+# kim
+
+Author: [Lasse Højgaard](https://github.com/lhotrifork)
+
+Use kim (https://github.com/rancher/kim) to build images for Tilt.
+
+## Functions
+
+### `kim_build(ref: str, import_path: str, deps: List[str] = [])`
+
+- **ref**: The name of the image to build. Must match the image
+   name in the Kubernetes resources you're deploying.
+- **import_path**: A Go import path of the binary to build.
+- **deps**: A list of dependencies that can trigger rebuilds.
+
+## Example Usage
+
+```
+load('ext://kim', 'kim_build')
+kim_build('hello-world-image', '.')
+```
+

--- a/kim/Tiltfile
+++ b/kim/Tiltfile
@@ -1,0 +1,29 @@
+
+# -*- mode: Python -*-
+
+def kim_build(ref, context, ignore=None, extra_flags=None):
+  """Use kim (https://github.com/rancher/kim) to build images for Tilt.
+  Args:
+    ref: The name of the image to build. Must match the image
+      name in the Kubernetes resources you're deploying.
+    context: The build context of the binary to build. Expressed as a file path.
+    ignore: Changes to the given files or directories do not trigger rebuilds.
+      Does not affect the build context.
+    extra_flags: Extra flags to pass to kim build. Expressed as an argv-style array.
+  """
+  extra_flags = extra_flags or []
+  extra_flags_str = ' '.join([shlex.quote(f) for f in extra_flags])
+
+  push_cmd = "echo already pushed $EXPECTED_REF"
+
+  custom_build(
+    ref=ref,
+    command=(
+      "set -ex\n" +
+      "kim build -t $EXPECTED_REF %s %s\n" +
+      push_cmd
+    ) % (extra_flags_str, shlex.quote(context)),
+    ignore=ignore,
+    deps=[context],
+    skips_local_docker=True,
+  )

--- a/kim/Tiltfile
+++ b/kim/Tiltfile
@@ -1,29 +1,29 @@
 
 # -*- mode: Python -*-
 
-def kim_build(ref, context, ignore=None, extra_flags=None):
+def kim_build(ref, context, ignore=None, extra_flags=None, **kwargs):
   """Use kim (https://github.com/rancher/kim) to build images for Tilt.
   Args:
     ref: The name of the image to build. Must match the image
       name in the Kubernetes resources you're deploying.
-    context: The build context of the binary to build. Expressed as a file path.
+    context: The build context of the image to build. Expressed as a file path.
     ignore: Changes to the given files or directories do not trigger rebuilds.
       Does not affect the build context.
     extra_flags: Extra flags to pass to kim build. Expressed as an argv-style array.
+    **kwargs: will be passed to the underlying `custom_build` call
   """
   extra_flags = extra_flags or []
   extra_flags_str = ' '.join([shlex.quote(f) for f in extra_flags])
 
-  push_cmd = "echo already pushed $EXPECTED_REF"
 
   custom_build(
     ref=ref,
     command=(
-      "set -ex\n" +
       "kim build -t $EXPECTED_REF %s %s\n" +
-      push_cmd
     ) % (extra_flags_str, shlex.quote(context)),
     ignore=ignore,
     deps=[context],
     skips_local_docker=True,
+    disable_push=True,
+    **kwargs
   )

--- a/kim/Tiltfile
+++ b/kim/Tiltfile
@@ -18,9 +18,7 @@ def kim_build(ref, context, ignore=None, extra_flags=None, **kwargs):
 
   custom_build(
     ref=ref,
-    command=(
-      "kim build -t $EXPECTED_REF %s %s\n" +
-    ) % (extra_flags_str, shlex.quote(context)),
+    command="kim build -t $EXPECTED_REF %s %s\n" % (extra_flags_str, shlex.quote(context)),
     ignore=ignore,
     deps=[context],
     skips_local_docker=True,


### PR DESCRIPTION
Hi,

Very simple extension that allows you to build images using kim https://github.com/rancher/kim 
Opens up support for running Tilt against Rancher Desktop https://github.com/rancher-sandbox/rancher-desktop and without having docker installed.

I was having some trouble with my local registry, so I've disabled the `kim push $EXPECTED_REF` command for now, as kim automatically pushes the image into the cluster.

Let me know what you think.
/Lasse