### PR TITLE
tarfetch: new tilt extension for reverse sync from containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`secret`](/secret): Functions for creating secrets.
 - [`snyk`](/snyk): Use [Snyk](https://snyk.io) to test your containers, configuration files, and open source dependencies.
 - [`syncback`](/syncback): Sync files/directories from your container back to your local FS.
+- [`tarfetch`](/tarfetch): Fetch new and updated files from a container to your local FS.
 - [`tests`](/tests): Some common configurations for running your tests in Tilt.
 - [`tilt_inspector`](/tilt_inspector): Debugging server for exploring internal Tilt state.
 - [`uibutton`](/uibutton): Customize your Tilt dashboard with [buttons to run a command](https://blog.tilt.dev/2021/06/21/uibutton.html).

--- a/tarfetch/README.md
+++ b/tarfetch/README.md
@@ -1,0 +1,48 @@
+# Tarfetch
+
+This extension leverages `kubectl exec` and `tar` to archive files in a Kubernetes container and then extract them to a destination on the local filesystem.
+
+## Overview
+
+Tarfetch provides a local resource method (`tarfetch`) to perform manually triggered reverse file synchronization (i.e. from pod container to local filesystem).
+
+Tarfetch resources can be triggered manually either via the Tilt Web UI, or via CLI using `tilt trigger <resource name>`.
+
+## Usage
+
+Tarfetch's only requirement is that both the local machine and container have `tar` installed. This is typically a given ([yes, even on Windows](https://docs.microsoft.com/en-us/virtualization/community/team-blog/2017/20171219-tar-and-curl-come-to-windows)).
+
+Import Tarfetch with the following in your Tiltfile:
+```
+load('ext://tarfetch', 'tarfetch')
+```
+
+A `tarfetch` resource can be created with the following parameters:
+
+Required parameters:
+* **name (str)**: a name for the local resource
+* **k8s_object (str)**: a Kubernetes object identifier (e.g. `deploy/my-deploy`, `job/my-job`, or a pod ID) that Tilt can use to select a pod. As per the behavior of `kubectl exec`, we will act on the first pod of the specified object, using the first container by default
+* **src_dir (str)**: directory *in the remote container* to sync from. Any `paths`, if specified, should be relative to this dir. This path *must* be a directory and must contain a trailing slash (e.g. `/app/` is acceptable; `/app` is not)
+
+Optional parameters:
+* **target_dir (str, optional)**: directory *on the local filesystem* to sync to. Defaults to `'.'`
+* **namespace (str, optiona)**: namespace of the desired `k8s_object`, if not `default`.
+* **container (str, optional)**: name of the container to sync from (by default, the first container)
+* **ignore (List[str], optional)**: patterns to ignore when syncing, [see `tar --exclude` documentation for details on supported patterns](https://www.gnu.org/software/tar/manual/html_node/exclude.html).
+* **keep_newer (bool, optional)**: prevents files overwrites when the destination file is newer. Default is true.
+* **verbose (bool, optional)**: if true, shows tar extract activity.
+* **labels (Union[str, List[str]], optional)**: used to group resources in the Web UI.
+
+### Example invocation
+
+Create a local resource called "tarfetch-app" which connects to the first pod of "deploy/frontend" (and the default container) and syncs the contents of "/app/" to local directory "./frontend" while ignoring all directories named "node_modules":
+
+```python
+tarfetch(
+   'tarfetch-app', 
+   'deployments/frontend',
+   '/app/',
+   './frontend',
+   ignore=["node_modules"]
+)
+ ```

--- a/tarfetch/Tiltfile
+++ b/tarfetch/Tiltfile
@@ -35,7 +35,7 @@ def tarfetch(
         paths specified, if relative, should be relative to this dir.
     :param target_dir (str, optional): directory ON THE LOCAL FS to sync to. Defaults to '.'
     :param namespace (str, optional): namespace of the desired k8s_object, if not `default`.
-    :param container (str, optiona): name of the container to sync from (by default,
+    :param container (str, optional): name of the container to sync from (by default,
         the first container)
     :param ignore (List[str], optional): patterns to ignore when syncing, see
         `tar --exclude` documentation for details on supported patterns.

--- a/tarfetch/Tiltfile
+++ b/tarfetch/Tiltfile
@@ -34,7 +34,7 @@ def tarfetch(
     :param src_dir (str): directory IN THE KUBERNETES CONTAINER to sync from. Any
         paths specified, if relative, should be relative to this dir.
     :param target_dir (str, optional): directory ON THE LOCAL FS to sync to. Defaults to '.'
-    :param namespace (str, optiona): namespace of the desired k8s_object, if not `default`.
+    :param namespace (str, optional): namespace of the desired k8s_object, if not `default`.
     :param container (str, optiona): name of the container to sync from (by default,
         the first container)
     :param ignore (List[str], optional): patterns to ignore when syncing, see

--- a/tarfetch/Tiltfile
+++ b/tarfetch/Tiltfile
@@ -1,0 +1,91 @@
+# -*- mode: Python -*-
+
+DEFAULT_EXCLUDES = [
+    ".git",
+    ".gitignore",
+    ".dockerignore",
+    "Dockerfile",
+    ".tiltignore",
+    "Tiltfile",
+    "tilt_modules",
+]
+
+def tarfetch(
+    name,
+    k8s_object,
+    src_dir,
+    target_dir=".",
+    namespace="default",
+    container="",
+    ignore=None,
+    keep_newer=True,
+    verbose=False,
+    labels=tuple()
+):
+    """
+    Create a local resource that will (via rsync) sync the specified files
+    from the specified k8s object to the local filesystem.
+
+    :param name (str): name of the created local resource.
+    :param k8s_object (str): a Kubernetes object identifier (e.g. deploy/my-deploy,
+        job/my-job, or a pod ID) that Tilt can use to select a pod. As per the
+        behavior of `kubectl exec`, we will act on the first pod of the specified
+        object, using the first container by default.
+    :param src_dir (str): directory IN THE KUBERNETES CONTAINER to sync from. Any
+        paths specified, if relative, should be relative to this dir.
+    :param target_dir (str, optional): directory ON THE LOCAL FS to sync to. Defaults to '.'
+    :param namespace (str, optiona): namespace of the desired k8s_object, if not `default`.
+    :param container (str, optiona): name of the container to sync from (by default,
+        the first container)
+    :param ignore (List[str], optional): patterns to ignore when syncing, see
+        `tar --exclude` documentation for details on supported patterns.
+    :param keep_newer (bool, optional): prevents files overwrites when the destination
+        file is newer. Default is true.
+    :param verbose (bool, optional): if true, shows tar extract activity.
+    :return:
+    """
+
+    # Verify inputs
+    if not src_dir.endswith("/"):
+        fail(
+            "src_dir must be a directory and have a trailing slash (because of rsync syntax rules)"
+        )
+
+    to_exclude = ignore
+    if not ignore:
+        to_exclude = []
+
+    # Apply defaults
+    to_exclude = DEFAULT_EXCLUDES + to_exclude
+
+    excludes = " ".join(["--exclude={}".format(ex) for ex in to_exclude])
+
+    # bundle container flag with k8s object specifier
+    if container:
+        k8s_object = "{obj} -c {container}".format(obj=k8s_object, container=container)
+
+    target_dir_bat = target_dir.replace("/", "\\")
+    local(["mkdir", "-p", target_dir], command_bat="mkdir {} || ver>nul".format(target_dir_bat))
+
+    local_resource(
+        name,
+        (
+            "(" +
+            "kubectl exec -i -n {namespace} {k8s_object} -- " +
+            "tar -c -f - --directory={src_dir} {exclude} ." +
+            ") | " +
+            "tar -x -f - {verbose} {keep_newer} --directory={target_dir} && " +
+            "echo Done."
+        ).format(
+            namespace=namespace,
+            k8s_object=k8s_object,
+            exclude=excludes,
+            src_dir=src_dir,
+            target_dir=target_dir,
+            keep_newer="--keep-newer-files" if keep_newer else "",
+            verbose="--verbose" if verbose else "",
+        ),
+        trigger_mode=TRIGGER_MODE_MANUAL,
+        auto_init=False,
+        labels=labels,
+    )


### PR DESCRIPTION
I wrote this extension after spending a few days working through multiple challenges related to using syncback on Windows. While this extension is not as full-featured as the rsync-based syncback extension, it serves my purposes and those of my co-workers well enough in retrieving new and changed files from Kubernetes containers.

I am not too attached to the name, formatting (I tried to adhere to Black formatting), etc. and am open to critique should anything need changed or refined.

I hope this can help others as much as it is helping me.
