### PR TITLE
namespace Add labels and annotation options to namespace_create and namespace_yaml

### DIFF
--- a/namespace/README.md
+++ b/namespace/README.md
@@ -7,11 +7,11 @@ namespaces on Kubernetes objects.
 
 ## Functions
 
-### `namespace_yaml(name: str): Blob`
+### `namespace_yaml(name: str, annotations: List [str] = [], labels: List [str] = []): Blob`
 
 Returns YAML for a Kubernetes namespace.
 
-### `namespace_create(name: str, allow_duplicates: boolean = False)`
+### `namespace_create(name: str, allow_duplicates: boolean = False, annotations: List [str] = [], labels: List [str] = [])`
 
 Deploys a namespace to the cluster. Equivalent to
 
@@ -41,6 +41,18 @@ load('ext://namespace', 'namespace_create', 'namespace_inject')
 ns = 'user-%s' % os.environ.get('USER', 'anonymous')
 namespace_create(ns)
 k8s_yaml(namespace_inject(read_file('deployment.yaml'), ns))
+```
+
+### Attach annotations and labels
+
+```
+load('ext://namespace', 'namespace_create', 'namespace_inject')
+namespace_create(
+    'my-namespace',
+    annotations=['kubernetes.io/metadata.name: my-namespace'],
+    labels=['kubernetes.io/metadata.name: my-namespace']
+)
+k8s_yaml(namespace_inject(read_file('deployment.yaml'), 'my-namespace'))
 ```
 
 ## Caveats

--- a/namespace/Tiltfile
+++ b/namespace/Tiltfile
@@ -1,22 +1,34 @@
 # -*- mode: Python -*-
 
-def namespace_yaml(name):
+def namespace_yaml(name, annotations=[], labels=[]):
   """Returns YAML for a namespace
 
   Args:
     name: The namespace name. Currently not validated.
+    annotations: Annotations applied to the namespace metadata
+    labels: Labels applied to the namespace metadata
 
   Returns:
     The namespace YAML as a blob
   """
+  annotations_str = ''
+  labels_str = ''
+  if (len(annotations) > 0):
+    annotations_str = """  annotations:
+%s
+""" % '\n'.join(["    %s" % s for s in annotations])
+  if (len(labels) > 0):
+    labels_str = """  labels:
+%s
+""" % '\n'.join(["    %s" % s for s in labels])
 
   return blob("""apiVersion: v1
 kind: Namespace
 metadata:
   name: %s
-""" % name)
+%s%s""" % (name, annotations_str, labels_str))
 
-def namespace_create(name, allow_duplicates=False):
+def namespace_create(name, allow_duplicates=False, annotations=[], labels=[]):
   """Creates a namespace in the current Kubernetes cluster.
 
   Args:
@@ -24,8 +36,13 @@ def namespace_create(name, allow_duplicates=False):
     allow_duplicates: Whether or not k8s should be allowed to have two
       instances of the same resource. Useful if you have more than one
       Tiltfile trying to create the same namespace.
+    annotations: Annotations applied to the namespace metadata
+    labels: Labels applied to the namespace metadata
   """
-  k8s_yaml(namespace_yaml(name), allow_duplicates=allow_duplicates)
+  k8s_yaml(
+    namespace_yaml(name, annotations=annotations, labels=labels),
+    allow_duplicates=allow_duplicates
+  )
 
 def namespace_inject(x, ns):
   """Takes K8s yaml, sets its namespace to `ns`, and returns it as a blob.


### PR DESCRIPTION
This commit adds optional parameters to the namespace functions to set labels and annotations at namespace creation time. If either parameter is not set, the corresponding section is excluded from the yaml.