### PR TITLE
tilt-extensions: fix tilt command lines for objects starting with `--`

### DIFF
--- a/cancel/kill_cmd.sh
+++ b/cancel/kill_cmd.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 CMD_NAME="$1"
 shift
 
-PID=$(tilt get cmd "$CMD_NAME" -o "jsonpath={.status.running.pid}")
+PID=$(tilt get cmd -o "jsonpath={.status.running.pid}" -- "$CMD_NAME")
 if [[ "$PID" == "" ]]; then
     echo "Cmd $CMD_NAME not running"
     exit 1

--- a/cancel/reconcile_cancel_btn.sh
+++ b/cancel/reconcile_cancel_btn.sh
@@ -14,11 +14,11 @@ echo "reconciling $cmd_name"
 
 cancel_cmd_name="$cmd_name:cancel"
 cancel_button_name="$cmd_name:cancel"
-cmd=$(tilt get cmd "$cmd_name" -o json --ignore-not-found)
+cmd=$(tilt get cmd -o json --ignore-not-found -- "$cmd_name")
 
 function delete_children {
-    tilt delete cmd "$cancel_cmd_name" --ignore-not-found
-    tilt delete uibutton "$cancel_button_name" --ignore-not-found
+    tilt delete cmd --ignore-not-found -- "$cancel_cmd_name"
+    tilt delete uibutton --ignore-not-found -- "$cancel_button_name"
     exit 0
 }
 

--- a/ngrok/ngrok-reconcile-config.sh
+++ b/ngrok/ngrok-reconcile-config.sh
@@ -23,7 +23,7 @@ fi
 for name in $names;
 do
     short=${name#configmap.tilt.dev/}
-    cm="$(tilt get configmap "$short" -o json)"
+    cm="$(tilt get configmap -o json -- "$short")"
     value="$(echo "$cm" | jq -r ".data.enabled")"
     port_list="$(echo "$cm" | jq -r '.data.ports')"
     location="$(echo "$cm" | jq -r ".data.resource")"
@@ -40,7 +40,8 @@ do
 done
 
 new_config="tunnels:"
-for tunnel in "${tunnels[@]}";
+# https://stackoverflow.com/a/7577209
+for tunnel in ${tunnels[@]+"${tunnels[@]}"}
 do
     new_config="$new_config
 $tunnel"

--- a/ngrok/ngrok-reconcile-uiresource.sh
+++ b/ngrok/ngrok-reconcile-uiresource.sh
@@ -13,7 +13,7 @@ echo "reconciling $name"
 
 disabled="true"
 ports=()
-links="$(tilt get uiresource "$name" -o jsonpath='{range .status.endpointLinks[*]}{.url}{"\n"}{end}')"
+links="$(tilt get uiresource -o jsonpath='{range .status.endpointLinks[*]}{.url}{"\n"}{end}' -- "$name")"
 for link in $links;
 do
     host="localhost"
@@ -26,13 +26,13 @@ done
 
 child_name="ngrok:$name"
 if [[ "$disabled" == "true" ]]; then
-    tilt delete uibutton "$child_name" --ignore-not-found
-    tilt delete configmap "$child_name" --ignore-not-found
-    tilt delete cmd "$child_name" --ignore-not-found
+    tilt delete uibutton --ignore-not-found -- "$child_name"
+    tilt delete configmap --ignore-not-found -- "$child_name"
+    tilt delete cmd --ignore-not-found -- "$child_name"
     exit 0
 fi
 
-cm_enabled="$(tilt get configmap "$child_name" --ignore-not-found -o jsonpath='{.data.enabled}')"
+cm_enabled="$(tilt get configmap --ignore-not-found -o jsonpath='{.data.enabled}' -- "$child_name")"
 if [[ "$cm_enabled" == "" ]]; then
     cm_enabled="false"
 fi

--- a/ngrok/toggle-ngrok.sh
+++ b/ngrok/toggle-ngrok.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 name="$1"
 child_name="ngrok:$name"
-cm="$(tilt get configmap "$child_name" -o json)"
+cm="$(tilt get configmap -o json -- "$child_name")"
 enabled="$(echo "$cm" | jq -r ".data.enabled")"
 new_val="true"
 new_text="stop ngrok"
@@ -20,8 +20,8 @@ if [[ "$enabled" == "true" ]]; then
     new_icon="play_circle_outline"
 fi
 
-tilt patch uibutton "$child_name" -p "{\"spec\":{\"text\":\"$new_text\", \"iconName\":\"$new_icon\"}}"
-tilt patch configmap "$child_name" -p "{\"data\":{\"enabled\":\"$new_val\"}}"
+tilt patch uibutton -p "{\"spec\":{\"text\":\"$new_text\", \"iconName\":\"$new_icon\"}}" -- "$child_name"
+tilt patch configmap -p "{\"data\":{\"enabled\":\"$new_val\"}}" -- "$child_name"
 
 if [[ "$enabled" != "true" ]]; then
     echo "ngrok tunnel started"


### PR DESCRIPTION
Fixes #262 

I did a git grep for `tilt get`, `tilt delete`, `tilt apply`, `tilt patch`, `tilt create`, and fixed any instances where object names were not preceded by `--`.

Also fixed a (harmless, I think) unbound variable error in the ngrok extension.