### PR TITLE
tilt-extensions: fix cancel cleanup

### DIFF
--- a/cancel/reconcile_cancel_btn.sh
+++ b/cancel/reconcile_cancel_btn.sh
@@ -24,7 +24,7 @@ function delete_children {
 
 # Check if the object has been deleted.
 name_in_json=$(echo "$cmd" | jq -r '.metadata.name')
-if [[ "$name_in_json" == "null" ]]; then
+if [[ "$cmd" == "" || "$name_in_json" == "null" ]]; then
     delete_children
 fi
 


### PR DESCRIPTION
Fixes #266

It turns out `echo "" | jq -r '.metadata.name'` outputs the empty string rather than `null`, so we weren't deleting buttons from cmds that got deleted by CmdServers.