### PR TITLE
kubectl_build: Handle dockerfile_contents

### DIFF
--- a/kubectl_build/Tiltfile
+++ b/kubectl_build/Tiltfile
@@ -66,7 +66,11 @@ def kubectl_build(ref, context, build_args={}, dockerfile=None,
     command += [shlex.quote(context)]
     command = pre_command + ' '.join(command)
 
-    custom_build(ref, command, [context], disable_push=True, skips_local_docker=True, live_update=live_update,
+    deps = [context]
+    if dockerfile_path != '-':
+        deps.append(dockerfile_path)
+
+    custom_build(ref, command, deps, disable_push=True, skips_local_docker=True, live_update=live_update,
                  match_in_env_vars=match_in_env_vars, ignore=ignore, entrypoint=entrypoint)
 
 


### PR DESCRIPTION
Like tilt,
- it pipes the content into the docker process,
- it checks whether both dockerfile and dockerfile_contents are provided and fails in that case.

Also, when neither dockerfile nor dockerfile_contents where
provided, the previous default behavior was to use 'Dockerfile' as
default value, while tilt defaults to context + '/Dockerfile'.

Now, the behavior appears to be more similar to tilt's w.r.t. dockerfile and dockerfile_contents.