### PR TITLE
Improvements to the pack build command

### DIFF
--- a/pack/README.md
+++ b/pack/README.md
@@ -21,10 +21,12 @@ k8s_resource('example-deployment', port_forwards=8000)
 The `pack` function can take a few arguments:
 
 - `name`: name of the image to be built
+- `pull_policy`: pull policy used by pack, defaults to `if-not-present`
 - `path`: path to application directory, defaults to the current working directory
 - `builder`: builder image, defaults to gcr.io/paketo-buildpacks/builder:base
+- `deps`: a list of dependencies, defaults to `path`
 - `buildpacks`: a list of buildpacks to use. (list[str])
-- `env_vars`: a list of environment variables. (list[str])
+- `env_vars`: a list of environment variables, defaults to `BP_LIVE_RELOAD_ENABLED=true` (list[str])
 
 The function also supports all of the properties of [`custom_build`](https://docs.tilt.dev/api.html#api.custom_build) so
 you can ignore files, override the entrypoint or set live updates as usual.
@@ -38,6 +40,55 @@ pack(
   builder='gcr.io/paketo-buildpacks/builder:tiny'
 )
 ```
+
+## Examples
+
+### Java
+
+1. Use the [Tilt example repo](https://github.com/tilt-dev/tilt-example-java)
+2. Use the following `Tiltfile`
+
+```
+# -*- mode: Python -*-
+
+load('ext://pack', 'pack')
+
+pack(
+    'example-java-image',
+    deps=['./bin/main'],
+    live_update = [
+        sync('./bin/main', '/workspace/BOOT-INF/classes'),
+    ],
+)
+k8s_yaml('kubernetes.yaml')
+k8s_resource('example-java', port_forwards=8000)
+```
+
+Then `tilt up`. Modifications are live synced into the application container.
+
+This example requires Visual Studio Code with the Java and Gradle extensions. VS Code will compile on save and put the compiled changes in `./bin/main`. Tilt then syncs those into the container. You will need to adjust the `deps` and `live_update` path if you're using a different IDE or building with Gradle directly where compiled artifacts are placed in a different location.
+
+### Node.js
+
+1. Use the [Tilt example repo](https://github.com/tilt-dev/tilt-example-nodejs)
+2. Use the following `Tiltfile`
+
+```
+# -*- mode: Python -*
+
+load('ext://pack', 'pack')
+
+pack(
+    'example-nodejs-image',
+    live_update = [
+        sync('./', '/workspace/'),
+    ])
+
+k8s_yaml('kubernetes.yaml')
+k8s_resource('example-nodejs', port_forwards=8000)
+```
+
+Then `tilt up`. Modifications are live synced into the application container.
 
 ## Requirements
 

--- a/pack/Tiltfile
+++ b/pack/Tiltfile
@@ -3,14 +3,15 @@
 def pack(
   name, 
   path=".",
-  builder="gcr.io/paketo-buildpacks/builder:base", 
+  builder="gcr.io/paketo-buildpacks/builder:base",
   buildpacks=[],
   env_vars=[],
+  pull_policy="if-not-present",
+  deps=[],
   **kwargs
   ):
     """
     Build a container image using pack and buildpacks.
-
     Args:
       name: name of the image to build.
       path: path to application directory, defaults to current working directory.
@@ -23,6 +24,14 @@ def pack(
     # Remove possible tag from image name
     name = name.split(":")[0]
 
+    envs = list(env_vars)
+    if 'BP_LIVE_RELOAD_ENABLED=true' not in envs:
+        envs.append('BP_LIVE_RELOAD_ENABLED=true')
+
+    deps_copy = list(deps)
+    if len(deps_copy) == 0:
+        deps_copy = [path]
+
     caching_ref = name + ":tilt-build-pack-caching"
 
     pack_build_cmd = " ".join([
@@ -30,8 +39,9 @@ def pack(
       caching_ref,
       "--path " + path,
       "--builder " + builder,
+      "--pull-policy " + pull_policy,
       " ".join(["--buildpack " + s for s in buildpacks]),
-      " ".join(["--env " + s for s in env_vars]),
+      " ".join(["--env " + s for s in envs]),
     ])
 
     docker_tag_cmd = " ".join([
@@ -43,6 +53,6 @@ def pack(
     custom_build(
         name,
         pack_build_cmd + " && " + docker_tag_cmd,
-        [path],
+        deps=deps_copy,
         **kwargs
     )


### PR DESCRIPTION
- Sets default pull policy to if-not-present, which improves speed (user configurable)
- Adds env BP_LIVE_RELOAD_ENABLED=true, if it's not present
- Sets path as the default deps, but allows user to modify them

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>