### PR TITLE
nix: added build_nix_image

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`tilt_inspector`](/tilt_inspector): Debugging server for exploring internal Tilt state.
 - [`uibutton`](/uibutton): Customize your Tilt dashboard with [buttons to run a command](https://blog.tilt.dev/2021/06/21/uibutton.html).
 - [`wait_for_it`](/wait_for_it): Wait until command output is equal to given output.
+- [`nix`](/nix): Use [nix](https://nixos.org/guides/install-nix.html) to build nix-based container images.
 
 ## Contribute an Extension
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,25 @@
+# nix
+
+Use build_nix_image (https://nix.dev/tutorials/building-and-running-docker-images) to build images for Tilt.
+
+## Requirements
+
+- `nix` (https://nixos.org/guides/install-nix.html)
+
+## Functions
+
+### `build_nix_image(ref: str, import_path: str = "", attr_path: str = "", deps: List[str] = [])`
+
+- **ref**: The name of the image to build. Must match the image
+name in the Kubernetes resources you're deploying.
+- **path**: The path to your nix expression.
+- **attr_path**: The attribute from the top-level nix expression containing the image you want to build.
+- **deps**: A list of dependencies that can trigger rebuilds.
+
+## Example Usage
+
+```
+load('ext://nix', 'build_nix_image')
+build_nix_image("hello-world-image", "./nix/image.nix", "hello-world-image", "./nix/image.nix")
+```
+

--- a/nix/Tiltfile
+++ b/nix/Tiltfile
@@ -1,0 +1,26 @@
+def build_nix_image(ref, path = "", attr_path = "", deps = []):
+    build_cmd = "nix-build --out-link $(mktemp -u) {attr} {path}".format(
+        attr = " --attr " + attr_path if attr_path else "",
+        path = path,
+    )
+
+    #hopefully docker does not change output from docker load
+    #this sed expression extracts the name from docker load stdout
+    sed_expr = r"s@Loaded image: \(\S*\)@\1@"
+    commands = [
+        "IMG_NAME=$(docker load --input $({build_cmd})|sed '{sed_expr}')"
+            .format(build_cmd = build_cmd, sed_expr = sed_expr),
+        "docker tag $IMG_NAME $EXPECTED_REF",
+    ]
+    custom_build(
+        ref,
+        command = [
+            "nix-shell",
+            "--packages",
+            "gnused",
+            "coreutils",
+            "--run",
+            ";\n".join(commands),
+        ],
+        deps = deps,
+    )

--- a/nix/test/Tiltfile
+++ b/nix/test/Tiltfile
@@ -1,0 +1,4 @@
+load("../Tiltfile", "build_nix_image")
+
+k8s_yaml("deployment.yaml")
+build_nix_image("hello-world-image", "./nix/image.nix", "hello-world-image", "./nix/image.nix")

--- a/nix/test/deployment.yaml
+++ b/nix/test/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-world
+spec:
+  selector:
+    matchLabels:
+      app: hello-world
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: hello-world
+    spec:
+      containers:
+        - name: hello-world
+          image: hello-world-image
+          ports:
+            - containerPort: 8000

--- a/nix/test/nix/image.nix
+++ b/nix/test/nix/image.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> { }
+, pkgsLinux ? import <nixpkgs> { system = "x86_64-linux"; }
+}:
+{
+  hello-world-image = pkgs.dockerTools.buildLayeredImage {
+    name = "hello-world";
+    config = {
+      Cmd = [
+        "${pkgsLinux.python3}/bin/python" "-m" "http.server" "8000"
+      ];
+      ExposedPorts = {
+        "8000/tcp" = { };
+      };
+    };
+  };
+}

--- a/nix/test/test.sh
+++ b/nix/test/test.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -ex
+
+cd "$(dirname "$0")"
+export TILT_PORT=9393
+
+tilt ci
+tilt down


### PR DESCRIPTION
Added function to build images with nix.
I used `sed` to extract image-name from `docker load`, it kindof relies on docker not changing output from `docker load`.
Without that part, user would have to pass in the full name of the docker image  being created by nix.
Which is optional in nix, you dont have to supply a name, which will cause it to have autogenerated name.
So its nice if we can capture it, and not sure if there is a better way.