### PR TITLE
Value from build arg dictionary should join as single string

### DIFF
--- a/kubectl_build/Tiltfile
+++ b/kubectl_build/Tiltfile
@@ -36,7 +36,7 @@ def kubectl_build(ref, context, build_args={}, dockerfile=None,
     if registry_secret:
         command += ['--registry-secret', registry_secret]
     for arg, value in build_args.items():
-        command += ['--build-arg', arg + '=', value]
+        command += ['--build-arg', arg + '=' + value]
     if target:
         command += ['--target', target]
     if extra_tag:


### PR DESCRIPTION
While using the `kubectl_build` extension, I was unable to pass in build arguments. It appears that docker expects `key=value` as a single string.

The current output is the following and is failing.
`--build-arg mykey= myvalue` <-- note the space after the equal operator

Correct parameter to be passed in should look like so.
`--build-arg mykey=myvalue`

This has been tested successfully in my local environment.