### PR TITLE
circleci: update ci image to go 1.17

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -3,14 +3,18 @@ FROM tiltdev/tilt:latest
 # Utils for our CI
 RUN apt update && apt install -y git build-essential
 RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-COPY --from=golang:1.16-buster /usr/local/go /usr/local/go
+COPY --from=golang:1.17-buster /usr/local/go /usr/local/go
 ENV PATH=/root/go/bin:/usr/local/go/bin:$PATH
 
 RUN mkdir -p /root/go/bin
-RUN curl -sSL https://github.com/google/ko/releases/download/v0.8.3/ko_0.8.3_Linux_x86_64.tar.gz | tar xzf - ko && \
+RUN curl -sSL https://github.com/google/ko/releases/download/v0.9.3/ko_0.9.3_Linux_x86_64.tar.gz | tar xzf - ko && \
   chmod +x ko && \
   mv ko /root/go/bin/ko && \
   which ko
+
+RUN curl -sSL https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/releases/download/v0.1.4/kubectl-buildkit_0.1.4_amd64.deb > kubectl-buildkit.deb && \
+  dpkg -i kubectl-buildkit.deb && \
+  apt install -f
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   validate:
     docker:
-      - image: tiltdev/tilt-extensions-ci@sha256:1fef97113de8538066e67d220367d953056993aca333382aca1e91b35c907bf4
+      - image: tiltdev/tilt-extensions-ci@sha256:8e11cf6547ce8b8279637330980b3f257b1d85fafbd2d5ede5fdf72b1b4e1b0b
 
     steps:
       - checkout
@@ -11,7 +11,7 @@ jobs:
 
   shellcheck:
     docker:
-      - image: tiltdev/tilt-extensions-ci@sha256:1fef97113de8538066e67d220367d953056993aca333382aca1e91b35c907bf4
+      - image: tiltdev/tilt-extensions-ci@sha256:8e11cf6547ce8b8279637330980b3f257b1d85fafbd2d5ede5fdf72b1b4e1b0b
 
     steps:
       - checkout
@@ -19,7 +19,7 @@ jobs:
 
   test:
     docker:
-      - image: tiltdev/tilt-extensions-ci@sha256:1fef97113de8538066e67d220367d953056993aca333382aca1e91b35c907bf4
+      - image: tiltdev/tilt-extensions-ci@sha256:8e11cf6547ce8b8279637330980b3f257b1d85fafbd2d5ede5fdf72b1b4e1b0b
 
     steps:
       - setup_remote_docker:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`min_k8s_version`](/min_k8s_version): Require a minimum Kubernetes version to run this Tiltfile.
 - [`min_tilt_version`](/min_tilt_version): Require a minimum Tilt version to run this Tiltfile.
 - [`namespace`](/namespace): Functions for interacting with namespaces.
+- [`nix`](/nix): Use [nix](https://nixos.org/guides/install-nix.html) to build nix-based container images.
 - [`ngrok`](/ngrok): Expose public URLs for your services with [`ngrok`](https://ngrok.com/).
 - [`pack`](/pack): Build container images using [pack](https://buildpacks.io/docs/install-pack/) and [buildpacks](https://buildpacks.io/).
 - [`podman`](/podman): Build container images using [podman](https://podman.io)
@@ -44,7 +45,6 @@ All extensions have been vetted and approved by the Tilt team.
 - [`tilt_inspector`](/tilt_inspector): Debugging server for exploring internal Tilt state.
 - [`uibutton`](/uibutton): Customize your Tilt dashboard with [buttons to run a command](https://blog.tilt.dev/2021/06/21/uibutton.html).
 - [`wait_for_it`](/wait_for_it): Wait until command output is equal to given output.
-- [`nix`](/nix): Use [nix](https://nixos.org/guides/install-nix.html) to build nix-based container images.
 
 ## Contribute an Extension
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/kubectlbuild:

ab698efd55daa7680a3685bea898f49f7872b564 (2021-11-04 12:38:47 -0400)
circleci: update ci image to go 1.17

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics