### PR TITLE
nix: fix sed expression

### DIFF
--- a/nix/Tiltfile
+++ b/nix/Tiltfile
@@ -6,9 +6,9 @@ def build_nix_image(ref, path = "", attr_path = "", deps = []):
 
     #hopefully docker does not change output from docker load
     #this sed expression extracts the name from docker load stdout
-    sed_expr = r"s@Loaded image: \(\S*\)@\1@"
+    sed_expr = r"s@Loaded image: \(\S*\)@\1@p"
     commands = [
-        "IMG_NAME=$(docker load --input $({build_cmd})|sed '{sed_expr}')"
+        "IMG_NAME=$(docker load --input $({build_cmd})|sed -n '{sed_expr}')"
             .format(build_cmd = build_cmd, sed_expr = sed_expr),
         "docker tag $IMG_NAME $EXPECTED_REF",
     ]


### PR DESCRIPTION
Noticed some issues with the previous extraction of `$IMG_NAME` from `docker load`.
The stdout filtering/sed only worked when the image had been previously loaded, because then the stdout only contained a single line, otherwise docker printed multiple lines to stdout, so `$IMG_NAME` var got multiple lines, which resulted in the tagging process not working.
Now I use `-n` which suppress automatic printing of pattern space.
Then append `p` which prints the current pattern space, which results in only printint output from matching line.