### PR TITLE
honeycomb: report event at start rather than end

### DIFF
--- a/honeycomb/events.py
+++ b/honeycomb/events.py
@@ -67,7 +67,7 @@ for build in builds:
         'duration_ms': int((end_time - start_time).total_seconds() * 1000),
         'kind': 'dockerimage',
       },
-      'time': completed['finishedAt'],
+      'time': completed['startedAt'],
     })
 
 print(json.dumps(events))


### PR DESCRIPTION
Hello @landism, @nicksieger,

Please review the following commits I made in branch nicks/honeycomb3:

20b2fcd17de4b7abe3c579c45e725fa8b0fceeaa (2021-12-06 17:55:37 -0500)
honeycomb: report event at start rather than end

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics