### PR TITLE
docker_build_sub: handle the dockerfile= argument correctly

### DIFF
--- a/docker_build_sub/Tiltfile
+++ b/docker_build_sub/Tiltfile
@@ -41,4 +41,5 @@ def docker_build_sub(ref, context, extra_cmds, child_context=None, base_suffix='
   base_ref = '%s-base' % ref
   docker_build(base_ref, context, **kwargs)
   df = '\n'.join(['FROM %s' % base_ref] + extra_cmds)
-  docker_build(ref, child_context, dockerfile_contents=df, live_update=live_update, **kwargs)
+  child_kwargs = {k: v for k, v in kwargs.items() if k not in ["dockerfile_contents", "dockerfile"]}
+  docker_build(ref, child_context, dockerfile_contents=df, live_update=live_update, **child_kwargs)

--- a/docker_build_sub/test/Dockerfile
+++ b/docker_build_sub/test/Dockerfile
@@ -1,0 +1,1 @@
+FROM busybox

--- a/docker_build_sub/test/Tiltfile
+++ b/docker_build_sub/test/Tiltfile
@@ -1,0 +1,15 @@
+load('../Tiltfile', 'docker_build_sub')
+
+k8s_yaml('deployment.yaml')
+k8s_resource('example-html', port_forwards=[8000])
+
+# Add a live_update rule to our docker_build.
+docker_build_sub(
+  'example-html-image',
+  '.',
+  dockerfile='./Dockerfile',
+  extra_cmds=[
+    'WORKDIR /app',
+    'ADD . .',
+    'ENTRYPOINT ./main.sh',
+  ])

--- a/docker_build_sub/test/deployment.yaml
+++ b/docker_build_sub/test/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-html
+  labels:
+    app: example-html
+spec:
+  selector:
+    matchLabels:
+      app: example-html
+  template:
+    metadata:
+      labels:
+        app: example-html
+    spec:
+      containers:
+      - name: example-html
+        image: example-html-image
+        ports:
+        - containerPort: 8000
+        readinessProbe:
+          httpGet:
+            port: 8000

--- a/docker_build_sub/test/index.html
+++ b/docker_build_sub/test/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body style="font-size: 30px; font-family: sans-serif; margin: 0;">
+    <div style="display: flex; flex-direction: column; width: 100vw; height: 100vh; align-items: center; justify-content: center;">
+      <div>Hello world!</div>
+    </div>
+  </body>
+</html>

--- a/docker_build_sub/test/main.sh
+++ b/docker_build_sub/test/main.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Serving files on port 8000"
+busybox httpd -f -p 8000

--- a/docker_build_sub/test/test.sh
+++ b/docker_build_sub/test/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+set -ex
+
+tilt ci
+tilt down


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/sub:

407ac02c090f56b6237c9d8a5ee55640f1f8e552 (2021-12-10 09:49:02 -0500)
docker_build_sub: handle the dockerfile= argument correctly
see this report for more info: https://github.com/tilt-dev/tilt-extensions/pull/304

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics