### PR TITLE
syncback: extract syncback_command_args and syncback_command helpers

### DIFF
--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -11,7 +11,96 @@ local('{} {}'.format(verify_rsync_path, MIN_LOCAL_RSYNC_VERSION))
 
 DEFAULT_EXCLUDES = ['.git', '.gitignore', '.dockerignore', 'Dockerfile', '.tiltignore', 'Tiltfile', 'tilt_modules']
 
-def syncback(name, k8s_object, src_dir, ignore=None, delete=False, paths=None, target_dir='.', container='', namespace='', verbose=False, labels=[]):
+def syncback_command_args(k8s_object, src_dir, ignore=None, delete=False, paths=None, target_dir='.', container='', namespace='', verbose=False):
+    """
+    Generate a list of command arguments to run that will sync the specified files from the given k8s object to the local filesystem.
+    :param k8s_object (str): a Kubernetes object identifier (e.g. deploy/my-deploy, job/my-job, or a pod ID) that Tilt
+           can use to select a pod. As per the behavior of `kubectl exec`, we will act on the first pod of the specified
+           object, using the first container by default.
+    :param src_dir (str): directory IN THE KUBERNETES CONTAINER to sync from. Any paths specified, if relative,
+           should be relative to this dir.
+    :param ignore (List[str], optional): files to ignore when syncing (relative to src_dir).
+    :param delete (bool, optional): run rsync with the --delete flag, i.e. delete files locally if not present in
+           the container. By default, False. THIS OPTION RISKS WIPING OUT FILES that exist locally but not in the
+           container. Tilt will protect some files automatically, but we recommend syncing specific paths (via `paths`
+           and/or using the `ignore` parameter to explicitly protect other files that exist locally but not on the container.
+    :param paths (List[str], optional): paths IN THE KUBERNETES CONTAINER to sync, relative to src_dir. May be files or dirs.
+           Note that these must not begin with `./`. If this arg is not passed, sync all of src_dir.
+    :param target_dir (str, optional): directory ON THE LOCAL FS to sync to. Defaults to '.'
+    :param container (str, optiona): name of the container to sync from (by default, the first container)
+    :param namespace (str, optiona): namespace of the desired k8s_object, if not `default`.
+    :param verbose (bool, optional): if true, print additional rsync information.
+    """
+    # Verify inputs
+    if not src_dir.endswith('/'):
+        fail('src_dir must be a directory and have a trailing slash (because of rsync syntax rules)')
+
+    if paths:
+        for p in paths:
+            if p.startswith('./'):
+                fail('Found illegal path "{}": paths may not begin with ./ (because of rsync syntax rules)'.format(p))
+            if p.startswith('/'):
+                fail('Found illegal path "{}": paths may not begin with / and must be relative to src_dir (because of rsync syntax rules)'.format(p))
+
+    to_include = []
+    to_exclude = ignore
+    if not ignore:
+        to_exclude = []
+
+    if paths:
+        # TODO: if you're rsync-savvy you might want to do the wildcarding manually--
+        #   give an option to turn off automatic +'***'
+        to_include = ['--include={}***'.format(p) for p in paths]
+    else:
+        # Sync the entire src_dir. Danger, Will Robinson! Exclude some stuff
+        # that may exist locally but not in your container so it
+        # doesn't get wiped out locally on your first sync
+        to_exclude = DEFAULT_EXCLUDES + to_exclude
+
+    to_exclude = ['--exclude={}***'.format(ex) for ex in to_exclude]
+
+    # set remote name to a dummy name
+    remote_name = 'syncback'
+
+    # instead of wrestling with passing optional args to krsync.sh that do not
+    # then get passed to rsync, just bundle container and namespace flags with
+    # k8s object specifier (quoted 1st argument)
+    if container:
+        k8s_object = '{obj} -c {container}'.format(obj=k8s_object, container=container)
+
+    if namespace:
+        k8s_object = '{obj} -n {namespace}'.format(obj=k8s_object, namespace=namespace)
+
+    flags = '-aOv'
+    if verbose:
+        flags = '-aOvvi'
+
+    argv = [
+        krsync_path,
+        k8s_object,
+        flags,
+        '--progress',
+        '--stats',
+    ]
+    if delete:
+        argv.append('--delete')
+    argv.append('-T=/tmp/rsync.tilt')
+    argv.extend(to_include)
+    argv.extend(to_exclude)
+    argv.append(remote_name + ':' + src_dir)
+    argv.append(target_dir)
+    return argv
+
+
+def syncback_command(k8s_object, src_dir, ignore=None, delete=False, paths=None, target_dir='.', container='', namespace='', verbose=False):
+    """
+    Generate a properly-quoted shell command string that will sync the specified files from the given k8s object to the local filesystem.
+    """
+    argv = syncback_command_args(k8s_object, src_dir, ignore, delete, paths, target_dir, container, namespace, verbose)
+    return ' '.join([shlex.quote(arg) for arg in argv])
+
+
+def syncback(name, k8s_object, src_dir, ignore=None, delete=False, paths=None, target_dir='.', container='', namespace='', verbose=False, labels=[], resource_deps=[]):
     """
     Create a local resource that will (via rsync) sync the specified files
     from the specified k8s object to the local filesystem.
@@ -34,74 +123,23 @@ def syncback(name, k8s_object, src_dir, ignore=None, delete=False, paths=None, t
     :param namespace (str, optiona): namespace of the desired k8s_object, if not `default`.
     :param verbose (bool, optional): if true, print additional rsync information.
     :param labels (Union[str, List[str]], optional): Used to group resources in the Web UI.
-    if true, print additional rsync information.
-    :return:
+    :param resource_deps (Union[str, List[str]], optional): Used to declare dependencies on other resources.
     """
-
-    # Verify inputs
-    if not src_dir.endswith('/'):
-        fail('src_dir must be a directory and have a trailing slash (because of rsync syntax rules)')
-
-    if paths:
-        for p in paths:
-            if p.startswith('./'):
-                fail('Found illegal path "{}": paths may not begin with ./ (because of rsync syntax rules)'.format(p))
-            if p.startswith('/'):
-                fail('Found illegal path "{}": paths may not begin with / and must be relative to src_dir (because of rsync syntax rules)'.format(p))
-
-    # Construct include/exclude rules
-    incl_excl = ''
-
-    to_exclude = ignore
-    if not ignore:
-        to_exclude = []
-
-    if paths:
-        # TODO: if you're rsync-savvy you might want to do the wildcarding manually--
-        #   give an option to turn off automatic +'***'
-        includes = ' '.join(['--include="{}***"'.format(p) for p in paths])
-        incl_excl = '{} --exclude="*"'.format(includes)
-    else:
-        # Sync the entire src_dir. Danger, Will Robinson! Exclude some stuff
-        # that may exist locally but not in your container so it
-        # doesn't get wiped out locally on your first sync
-        to_exclude = DEFAULT_EXCLUDES + to_exclude
-
-    excludes = ' '.join(['--exclude="{}***"'.format(ex) for ex in to_exclude])
-    incl_excl = '{} {}'.format(excludes, incl_excl)
-
-    # set remote name to a dummy name
-    remote_name = 'syncback'
-
-    # instead of wrestling with passing optional args to krsync.sh that do not
-    # then get passed to rsync, just bundle container and namespace flags with
-    # k8s object specifier (quoted 1st argument)
-    if container:
-        k8s_object = '{obj} -c {container}'.format(obj=k8s_object, container=container)
-
-    if namespace:
-        k8s_object = '{obj} -n {namespace}'.format(obj=k8s_object, namespace=namespace)
-
-    flags = '-aOv'
-    if verbose:
-        flags = '-aOvvi'
-
-    delete_flag = ''
-    if delete:
-        delete_flag = '--delete'
-
     # Ensure extra kwargs are only passed to local_resource if specified to
     # provide backward compatibility with older version of tilt.
 
+    command = syncback_command(k8s_object, src_dir,
+                               ignore=ignore, delete=delete, paths=paths,
+                               target_dir=target_dir,
+                               container=container, namespace=namespace,
+                               verbose=verbose)
     extra_args = {}
 
     if labels:
         extra_args["labels"] = labels
 
-    local_resource(name, '{krsync} "{obj}" {flags} --progress --stats {delete} -T=/tmp/rsync.tilt {include_exclude} {remote}:{src} {target}'.
-                   format(krsync=krsync_path, obj=k8s_object, flags=flags, delete=delete_flag,
-                          include_exclude=incl_excl, remote=remote_name, src=src_dir, target=target_dir),
-               trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False, **extra_args)
+    if resource_deps:
+        extra_args["resource_deps"] = resource_deps
 
-    # TODO: not necessarily manual/can link up to a resource as a dep
+    local_resource(name, command, trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False, **extra_args)
 

--- a/syncback/test/Tiltfile
+++ b/syncback/test/Tiltfile
@@ -1,4 +1,5 @@
-load("../Tiltfile", "syncback")
+load("../Tiltfile", "syncback", "syncback_command_args")
+load("../../uibutton/Tiltfile", "cmd_button")
 
 src = str(local("mktemp -d | tee syncback-dir.txt")).strip("\n")
 python = os.path.join(src, "python")
@@ -39,6 +40,9 @@ spec:
           command: ["sh", "-c", "apk add rsync && nc -kl 10000"]
 """))
 
+k8s_resource("syncback-containers")
+cmd_button("Sync", "syncback-containers", syncback_command_args("deploy/syncback-test", "/root/", target_dir=rsync, container="rsync", namespace="syncback-test"))
+local_resource("syncback-button", "tilt get uibuttons/Sync -o jsonpath='{.spec.location.componentID}' > syncback-button.txt && tilt get cmd/btn-Sync", resource_deps=["syncback-containers"])
 
 local_resource("python-file", "kubectl exec --namespace syncback-test -c python deploy/syncback-containers -- touch /root/main.py",   resource_deps=["syncback-containers"])
 local_resource("ruby-file",   "kubectl exec --namespace syncback-test -c ruby   deploy/syncback-containers -- touch /root/main.rb",   resource_deps=["syncback-containers"])

--- a/syncback/test/Tiltfile
+++ b/syncback/test/Tiltfile
@@ -40,8 +40,7 @@ spec:
           command: ["sh", "-c", "apk add rsync && nc -kl 10000"]
 """))
 
-k8s_resource("syncback-containers")
-cmd_button("Sync", "syncback-containers", syncback_command_args("deploy/syncback-test", "/root/", target_dir=rsync, container="rsync", namespace="syncback-test"))
+cmd_button("Sync", "syncback-containers", syncback_command_args("deploy/syncback-containers", "/root/", target_dir=rsync, container="rsync", namespace="syncback-test"))
 local_resource("syncback-button", "tilt get uibuttons/Sync -o jsonpath='{.spec.location.componentID}' > syncback-button.txt && tilt get cmd/btn-Sync", resource_deps=["syncback-containers"])
 
 local_resource("python-file", "kubectl exec --namespace syncback-test -c python deploy/syncback-containers -- touch /root/main.py",   resource_deps=["syncback-containers"])

--- a/syncback/test/test.sh
+++ b/syncback/test/test.sh
@@ -13,5 +13,8 @@ kubectl exec -n syncback-test -c python deploy/syncback-containers -- sh -c "[ -
 kubectl exec -n syncback-test -c ruby deploy/syncback-containers -- sh -c "[ -f /bin/rsync.tilt ]"
 # Test that rsync was not copied because it was already installed
 kubectl exec -n syncback-test -c rsync deploy/syncback-containers -- sh -c "[ ! -f /bin/rsync.tilt ]"
+# Test that button was created with correct resource
+test -f syncback-button.txt -a "$(cat syncback-button.txt)" = syncback-containers
+
 tilt down --delete-namespaces
-rm -rf $syncback_dir syncback-dir.txt
+rm -rf $syncback_dir syncback-dir.txt syncback-button.txt


### PR DESCRIPTION
Allows installing syncback as a `cmd_button` in coordination with the `uibutton`
extension instead of as a local resource.

Example:
```starlark
load('ext://uibutton', 'cmd_button')
load('ext://syncback' 'syncback_command_args')

docker_build('myapp', './app')
k8s_yaml('app.yaml')
k8s_resource('myapp', port_forwards=[5000])

cmd_button('Sync', 'myapp', syncback_command_args('deploy/myapp', '/app'))
```
