### PR TITLE
kubefwd/ngrok: use portable mktemp invocation for macOS/Linux

### DIFF
--- a/kubefwd/Tiltfile
+++ b/kubefwd/Tiltfile
@@ -5,7 +5,7 @@ cfg = config.parse()
 
 namespaces = cfg.get('namespaces', [])
 
-trigger_file = str(local('mktemp --suffix -tilt-kubefwd')).strip()
+trigger_file = str(local('mktemp "${TMPDIR:-/tmp}/tilt-kubefwd.XXXXXXXXX"')).strip()
 
 # Creates a button that refreshes the kubefwd without
 # requiring new credentials.

--- a/ngrok/Tiltfile
+++ b/ngrok/Tiltfile
@@ -3,7 +3,7 @@ config.define_string("auth")
 cfg = config.parse()
 
 auth = cfg.get('auth', '')
-config_file = str(local('mktemp --suffix -tilt-ngrok.yml')).strip()
+config_file = str(local('mktemp "${TMPDIR:-/tmp}/tilt-ngrok.XXXXXXXXX"')).strip()
 
 local_resource(
   name='ngrok:status',


### PR DESCRIPTION
BSD `mktemp` has some differences compared to the GNU variant,
so this is the most portable way to make temporary files that
works across macOS + Linux that I could find. Note that the ngrok
file won't end in `.yml` anymore because BSD `mktemp` only allows
the randomized part of the template (i.e. `XXXXXX`) to be at the
END of the filename.

Both of these assume a POSIX-y env as-is (e.g. they're running
Bash scripts for their main operator functionality, so no attempt
at supporting Windows cmd is made here.