### PR TITLE
ngrok: fix error with no tunnels on macOS

### DIFF
--- a/ngrok/ngrok-run.sh
+++ b/ngrok/ngrok-run.sh
@@ -13,7 +13,7 @@ fi
 
 args+=("--config" "$config_file")
 
-if [[ "$(wc -l "$config_file" | cut -d ' ' -f 1)" == "0" ]]; then
+if [[ "$(wc -l "$config_file" | awk '{print $1}')" == "0" ]]; then
     args+=("--none")
 else
     args+=("--all")


### PR DESCRIPTION
Another small BSD vs GNU thing: `wc` prepends some spaces on the
BSD/macOS version:
```
$ wc -l "$config_file"
       0 /var/folders/r2/12r1dtqn2zqc4yg_kfnprfv80000gn/T//tilt-ngrok.y8z4hmDGs
```

Using `awk` works with both variations.

(Another variation would be `wc -l < "$config_file" | xargs` since
`wc` won't print the filename if reading from stdin and `xargs` trims
stuff, but that's a bit obtuse and abusing `xargs` IMO.)

I found this while verifying my `mktemp` fix (#312).