### PR TITLE
honeycomb: make the test wait a bit on the apiserver

### DIFF
--- a/honeycomb/test/events_test.py
+++ b/honeycomb/test/events_test.py
@@ -1,9 +1,22 @@
 import json
 import subprocess
 import unittest
+import time
 
 class TestHoneycomb(unittest.TestCase):
   def test_events(self):
+    # Wait until the apiserver catches up.
+    wait_count = 0
+    while wait_count < 3:
+      events = json.loads(subprocess.check_output(["python3", "../events.py"]))
+      if (len(events) == 2 and
+          events[0]['data']['update_status'] == 'ok' and
+          events[1]['data']['update_status'] == 'in_progress'):
+        break
+
+      time.sleep(1)
+      wait_count = wait_count + 1
+
     events = json.loads(subprocess.check_output(["python3", "../events.py"]))
     self.assertEqual(2, len(events))
     self.assertEqual('(Tiltfile)', events[0]['data']['name'])


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/honeycomb2:

da28f1675f86c3d5317136e5fa5eb2bc3214052e (2021-12-21 11:30:04 -0500)
honeycomb: make the test wait a bit on the apiserver

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics