### PR TITLE
tests: use local_resource instead of the test() built-in

### DIFF
--- a/tests/golang/Tiltfile
+++ b/tests/golang/Tiltfile
@@ -29,4 +29,4 @@ def test_go(name, package, deps, timeout='', tags=None, mod='', recursive=False,
     cmd = 'go test {mod_str} {tags_str} {timeout_str} {extra_args_str} {package}'.format(
           mod_str=mod_str, tags_str=tags_str, timeout_str=timeout_str,
           extra_args_str=extra_args_str, package=package)
-    test(name, cmd, deps=deps, ignore=ignore, **kwargs)
+    local_resource(name, cmd, deps=deps, ignore=ignore, allow_parallel=True, **kwargs)

--- a/tests/javascript/Tiltfile
+++ b/tests/javascript/Tiltfile
@@ -35,7 +35,7 @@ def _test_js(name, pkmanager, dir, deps=None, only_changed=True, with_install=Fa
     if ignore:
         all_ignores = [ig for ig in ignore]
     all_ignores.extend(install_deps + extra_ignores(pkmanager, project_root))
-    test(name, cmd, deps=file_deps, ignore=all_ignores, resource_deps=resource_deps, **kwargs)
+    local_resource(name, cmd, deps=file_deps, ignore=all_ignores, resource_deps=resource_deps, allow_parallel=True, **kwargs)
 
 
 def test_jest_npm(name, dir, deps=None, only_changed=True, with_install=False, project_root='', ignore=None, extra_args=None, **kwargs):


### PR DESCRIPTION
Hello @lizzthabet, @landism,

Please review the following commits I made in branch nicks/tests2:

a3401cc36b68c870e10b4e9680246eaab22442e3 (2022-01-04 18:20:06 -0500)
tests: use local_resource instead of the test() built-in

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics