### PR TITLE
color: add extension for ANSI codes in Tiltfile

### DIFF
--- a/color/README.md
+++ b/color/README.md
@@ -1,0 +1,42 @@
+# color
+Add ANSI color codes to your Tiltfile log messages.
+
+Works with Tiltfile built-ins such as `print`, `warn`, `fail`, `exit` in addition to custom functions.
+
+## Usage
+```python
+load('ext://color', 'color')
+
+print(color.red('ERROR: ') + 'Something went wrong')
+
+print('The {earth} is about 71% {water}.'.format(
+    earth=color.green('earth'),
+    water=color.blue('water')
+))
+```
+
+## API
+All color functions take a single argument (the string to be colorized) and return a string.
+
+Available color functions:
+* `color.black`
+* `color.red`
+* `color.green`
+* `color.yellow`
+* `color.blue`
+* `color.magenta`
+* `color.cyan`
+* `color.white`
+
+
+## Enable/Disable
+To disable colors from this extension, set the [`NO_COLOR`][no-color] environment variable, e.g. `NO_COLOR=1 tilt up`.
+
+Additionally, unless forcibly enabled, when running `tilt ci`, if running on Windows or `TERM=dumb`, colors will be automatically disabled to prevent compatibility issues.
+
+NOTE: Colors are automatically enabled when running `tilt up` regardless of OS/terminal support, as the Tilt web UI always supports color ANSI codes.
+
+You can force colors from this extension by setting the `FORCE_COLOR` environment variable, e.g. `FORCE_COLOR=1 tilt up`.
+(If both `NO_COLOR` and `FORCE_COLOR` are set, `NO_COLOR` will take precedence.)
+
+[no-color]: https://no-color.org/

--- a/color/Tiltfile
+++ b/color/Tiltfile
@@ -5,7 +5,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
-magenta='\033[0;35m'
+MAGENTA='\033[0;35m'
 CYAN='\033[0;36m'
 WHITE='\033[0;37m'
 
@@ -51,7 +51,7 @@ def blue(value):
 
 
 def magenta(value):
-    return _color(magenta, value)
+    return _color(MAGENTA, value)
 
 
 def cyan(value):

--- a/color/Tiltfile
+++ b/color/Tiltfile
@@ -1,0 +1,74 @@
+RESET='\033[0m'
+
+BLACK='\033[0;30m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+magenta='\033[0;35m'
+CYAN='\033[0;36m'
+WHITE='\033[0;37m'
+
+
+def should_enable_colors():
+    if 'NO_COLOR' in os.environ:
+        return False
+    if 'FORCE_COLOR' in os.environ:
+        return True
+    if (config.tilt_subcommand == 'ci' and
+        (os.getenv('TERM', '') == 'dumb' or os.name == 'nt')):
+        return False
+    return True
+
+
+colors_enabled = should_enable_colors()
+
+
+def _color(c, value):
+    if not colors_enabled:
+        return value
+    return c + value + RESET
+
+
+def black(value):
+    return _color(BLACK, value)
+
+
+def red(value):
+    return _color(RED, value)
+
+
+def green(value):
+    return _color(GREEN, value)
+
+
+def yellow(value):
+    return _color(YELLOW, value)
+
+
+def blue(value):
+    return _color(BLUE, value)
+
+
+def magenta(value):
+    return _color(magenta, value)
+
+
+def cyan(value):
+    return _color(CYAN, value)
+
+
+def white(value):
+    return _color(WHITE, value)
+
+
+color = struct(
+    black=black,
+    red=red,
+    green=green,
+    yellow=yellow,
+    blue=blue,
+    magenta=magenta,
+    cyan=cyan,
+    white=white,
+)

--- a/color/test/Tiltfile
+++ b/color/test/Tiltfile
@@ -1,0 +1,5 @@
+load('../Tiltfile', 'color')
+
+message = color.green('Hello') + ' ' + color.blue('World') + '!'
+
+local_resource('test', cmd='echo {message}'.format(message=shlex.quote(message)))

--- a/color/test/Tiltfile
+++ b/color/test/Tiltfile
@@ -3,3 +3,7 @@ load('../Tiltfile', 'color')
 message = color.green('Hello') + ' ' + color.blue('World') + '!'
 
 local_resource('test', cmd='echo {message}'.format(message=shlex.quote(message)))
+
+# ensure all the color functions can be called without error
+for c in dir(color):
+    print(getattr(color, c)(c))

--- a/color/test/test.sh
+++ b/color/test/test.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")"
+
+echo "--- COLORS ENABLED ---"
+expected="\x1b[0;32mHello\x1b[0m \x1b[0;34mWorld\x1b[0m!"
+out=$(tilt ci)
+echo "${out}"
+
+if ! test "${out#*"$expected"}" != "${expected}"; then
+    >&2 echo "Did not find expected output: '${expected}'"
+    exit 1
+else
+    echo "PASS"
+fi
+
+echo "--- COLORS DISABLED ---"
+expected="Hello World!"
+out=$(NO_COLOR=1 tilt ci)
+echo "${out}"
+
+if ! test "${out#*"$expected"}" != "${expected}"; then
+    >&2 echo "Did not find expected output: '${expected}'"
+    exit 1
+else
+    echo "PASS"
+fi


### PR DESCRIPTION
Add ANSI color codes to your Tiltfile log messages.

Works with Tiltfile built-ins such as `print`, `warn`, `fail`, `exit`
in addition to custom functions.

<img width="1420" alt="screenshot of colorized output from Tiltfile logging in CLI" src="https://user-images.githubusercontent.com/841263/149571883-f7459195-8495-4b66-8ed0-23b5669a5221.png">

<img width="617" alt="screenshot of colorized output from Tiltfile logging in web UI" src="https://user-images.githubusercontent.com/841263/149572002-8871119d-07d6-40bb-8937-43a4c20a58ae.png">

