### PR TITLE
helm_resource: fix sed errors on old macOS

### DIFF
--- a/helm_resource/Tiltfile
+++ b/helm_resource/Tiltfile
@@ -73,8 +73,8 @@ def helm_resource(
       # NOTE(nick): This is a PITA because it's hard to separate
       # out the repository from the tag.
       flags.extend([
-        '--set', '%s=$(echo "$TILT_IMAGE_%s" | sed -r \'s,:[^/]*$,,\')' % (shlex.quote(key[0]), i),
-        '--set', '%s=$(echo "$TILT_IMAGE_%s" | sed -r \'s,^.*:([^/]*)$,\\1,\')' % (shlex.quote(key[1]), i),
+        '--set', '%s=$(echo "$TILT_IMAGE_%s" | sed -e \'s,:[^/]*$,,\')' % (shlex.quote(key[0]), i),
+        '--set', '%s=$(echo "$TILT_IMAGE_%s" | sed -e \'s,^.*:\\([^/]*\\)$,\\1,\')' % (shlex.quote(key[1]), i),
       ])
     else:
       fail("invalid argument to image_keys at %s: %s" % (i, type(key)))

--- a/helm_resource/Tiltfile
+++ b/helm_resource/Tiltfile
@@ -73,8 +73,8 @@ def helm_resource(
       # NOTE(nick): This is a PITA because it's hard to separate
       # out the repository from the tag.
       flags.extend([
-        '--set', '%s=$(echo "$TILT_IMAGE_%s" | sed -e \'s,:[^/]*$,,\')' % (shlex.quote(key[0]), i),
-        '--set', '%s=$(echo "$TILT_IMAGE_%s" | sed -e \'s,^.*:\\([^/]*\\)$,\\1,\')' % (shlex.quote(key[1]), i),
+        '--set', '%s=$(echo "$TILT_IMAGE_%s" | sed \'s,:[^/]*$,,\')' % (shlex.quote(key[0]), i),
+        '--set', '%s=$(echo "$TILT_IMAGE_%s" | sed \'s,^.*:\\([^/]*\\)$,\\1,\')' % (shlex.quote(key[1]), i),
       ])
     else:
       fail("invalid argument to image_keys at %s: %s" % (i, type(key)))


### PR DESCRIPTION
Old versions of BSD `sed` don't include the `-r` flag for extended
regex (they instead use `-E`). This prevents things from working
on older macOS versions (e.g. 10.15).

Use `-e` instead for greater portability, which works fine for our
regexes with a slight extra escape on the capture group for BRE
compatibility.

Fixes #328.