### PR TITLE
Add echo option to prevent secrets from printing to stdout

### DIFF
--- a/secret/Tiltfile
+++ b/secret/Tiltfile
@@ -1,6 +1,6 @@
 # -*- mode: Python -*-
 
-def secret_yaml_generic(name, namespace="", from_file=None, secret_type=None, from_env_file=None):
+def secret_yaml_generic(name, namespace="", from_file=None, secret_type=None, from_env_file=None, echo_status=False):
   """Returns YAML for a generic secret
 
   Args:
@@ -57,9 +57,9 @@ def secret_yaml_generic(name, namespace="", from_file=None, secret_type=None, fr
       fail("Bad secret_type argument: %s" % secret_type)
 
   args.extend(["-o=yaml", "--dry-run=client"])
-  return local(args, quiet=True)
+  return local(args, quiet=True, echo_off=echo_status)
 
-def secret_from_dict(name, namespace="", inputs={}):
+def secret_from_dict(name, namespace="", inputs={}, echo_status=False):
     """Returns YAML for a generic secret
     Args:
         name: The configmap name.
@@ -87,7 +87,7 @@ def secret_from_dict(name, namespace="", inputs={}):
         args.extend(["--from-literal", "%s=%s" % (k,v)])
 
     args.extend(["-o=yaml", "--dry-run=client"])
-    return local(args, quiet=True)
+    return local(args, quiet=True, echo_off=echo_status)
 
 def secret_create_generic(name, namespace="", from_file=None, secret_type=None, from_env_file=None):
   """Creates a secret in the current Kubernetes cluster.
@@ -104,7 +104,7 @@ def secret_create_generic(name, namespace="", from_file=None, secret_type=None, 
   """
   k8s_yaml(secret_yaml_generic(name, namespace, from_file, secret_type, from_env_file))
 
-def secret_yaml_tls(name, cert, key, namespace=""):
+def secret_yaml_tls(name, cert, key, namespace="", echo_status=False):
   """Returns YAML for a TLS secret
 
   Args:
@@ -131,7 +131,7 @@ def secret_yaml_tls(name, cert, key, namespace=""):
     args.extend(["-n", namespace])
 
   args.extend(["-o=yaml", "--dry-run=client"])
-  return local(args, quiet=True)
+  return local(args, quiet=True, echo_off=echo_status)
 
 
 def secret_create_tls(name, cert, key, namespace=""):

--- a/secret/Tiltfile
+++ b/secret/Tiltfile
@@ -1,6 +1,6 @@
 # -*- mode: Python -*-
 
-def secret_yaml_generic(name, namespace="", from_file=None, secret_type=None, from_env_file=None, echo_status=False):
+def secret_yaml_generic(name, namespace="", from_file=None, secret_type=None, from_env_file=None):
   """Returns YAML for a generic secret
 
   Args:
@@ -57,9 +57,9 @@ def secret_yaml_generic(name, namespace="", from_file=None, secret_type=None, fr
       fail("Bad secret_type argument: %s" % secret_type)
 
   args.extend(["-o=yaml", "--dry-run=client"])
-  return local(args, quiet=True, echo_off=echo_status)
+  return local(args, quiet=True, echo_off=True)
 
-def secret_from_dict(name, namespace="", inputs={}, echo_status=False):
+def secret_from_dict(name, namespace="", inputs={}):
     """Returns YAML for a generic secret
     Args:
         name: The configmap name.
@@ -87,7 +87,7 @@ def secret_from_dict(name, namespace="", inputs={}, echo_status=False):
         args.extend(["--from-literal", "%s=%s" % (k,v)])
 
     args.extend(["-o=yaml", "--dry-run=client"])
-    return local(args, quiet=True, echo_off=echo_status)
+    return local(args, quiet=True, echo_off=True)
 
 def secret_create_generic(name, namespace="", from_file=None, secret_type=None, from_env_file=None):
   """Creates a secret in the current Kubernetes cluster.
@@ -104,7 +104,7 @@ def secret_create_generic(name, namespace="", from_file=None, secret_type=None, 
   """
   k8s_yaml(secret_yaml_generic(name, namespace, from_file, secret_type, from_env_file))
 
-def secret_yaml_tls(name, cert, key, namespace="", echo_status=False):
+def secret_yaml_tls(name, cert, key, namespace=""):
   """Returns YAML for a TLS secret
 
   Args:
@@ -131,7 +131,7 @@ def secret_yaml_tls(name, cert, key, namespace="", echo_status=False):
     args.extend(["-n", namespace])
 
   args.extend(["-o=yaml", "--dry-run=client"])
-  return local(args, quiet=True, echo_off=echo_status)
+  return local(args, quiet=True, echo_off=True)
 
 
 def secret_create_tls(name, cert, key, namespace=""):


### PR DESCRIPTION
Being that secrets generally contain sensitive keys, this PR adds an option to various methods within the `secret` extension where users will have the option to prevent secret creation from exposing keys in Tilt's UI/logging console.

Default option is set to `False` as the use case may not apply to all.