### PR TITLE
knative: fix local registry host parsing

### DIFF
--- a/knative/Tiltfile
+++ b/knative/Tiltfile
@@ -32,7 +32,7 @@ kubectl delete --ignore-not-found -f https://github.com/knative/serving/releases
   # TODO(nick): Once the registry is in the Tilt API,
   # we should read that here and use it to set knative configuration.
   patch_registry_cmd="""
-REGISTRY=$(kubectl get configmap -n kube-public local-registry-hosting -oyaml | grep "host:" | sed 's/ *host: *//')
+REGISTRY=$(kubectl get configmap -n kube-public local-registry-hosting -o=jsonpath='{.data.localRegistryHosting\\.v1}' | grep "host:" | sed 's/ *host: *//')
 if [ "$REGISTRY" != "" ]; then
   kubectl patch configmap/config-deployment \
     --namespace knative-serving \


### PR DESCRIPTION
The current code chokes if `last-applied-configuration` is present:
```
kubectl get configmap -n kube-public local-registry-hosting -oyaml                                                                              

apiVersion: v1
data:
  localRegistryHosting.v1: |
    host: localhost:55547
    hostFromClusterNetwork: k3d-runhub-registry:5000
    hostFromContainerRuntime: k3d-runhub-registry:5000
    help: https://k3d.io/usage/guides/registries/#using-a-local-registry
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"localRegistryHosting.v1":"host: localhost:55547\nhostFromClusterNetwork: k3d-runhub-registry:5000\nhostFromContainerRuntime: k3d-runhub-registry:5000\nhelp: https://k3d.io/usage/guides/registries/#using-a-local-registry\n"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"local-registry-hosting","namespace":"kube-public"}}
  creationTimestamp: "2022-02-15T20:59:40Z"
  name: local-registry-hosting
  namespace: kube-public
  resourceVersion: "371"
  uid: f20c740d-1e11-4639-bd53-df3a08c4a251
```
```
kubectl get configmap -n kube-public local-registry-hosting -oyaml | grep "host:" | sed 's/ *host: *//'

localhost:55547
      {"apiVersion":"v1","data":{"localRegistryHosting.v1":"localhost:55547\nhostFromClusterNetwork: k3d-runhub-registry:5000\nhostFromContainerRuntime: k3d-runhub-registry:5000\nhelp: https://k3d.io/usage/guides/registries/#using-a-local-registry\n"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"local-registry-hosting","namespace":"kube-public"}}
```
```
kubectl get configmap -n kube-public local-registry-hosting -o=jsonpath='{.data.localRegistryHosting\.v1}' | grep "host:" | sed 's/ *host: *//' 

localhost:55547
```