### PR TITLE
helm_remote/git_resource: use command list instead of shell escaping

### DIFF
--- a/git_resource/Tiltfile
+++ b/git_resource/Tiltfile
@@ -51,52 +51,46 @@ def git_checkout(repository_url, checkout_dir=None, unsafe_mode=False):
             tree = tree[7:]
 
         if not os.path.exists(checkout_dir):  # needs clone
+            clone_cmd = ['git','clone', repository_url, '--recurse-submodules', '--shallow-submodules']
             if is_branch or is_tag:
-                branch_flag = ''
+                clone_cmd.extend(['--depth', '1'])
                 if tree:
-                    branch_flag = '--branch %s' % tree
-
-                local('git clone {repository_url} --recurse-submodules --shallow-submodules --depth 1 {branch_flag} {checkout_dir}'.
-                      format(repository_url=repository_url,
-                             branch_flag=branch_flag,
-                             checkout_dir=shlex.quote(checkout_dir)),
-                      quiet=True)
+                    clone_cmd.extend(['--branch', tree])
+                clone_cmd.append(checkout_dir)
+                local(clone_cmd, quiet=True)
             else:
-                checkout_cmd = ''
+                clone_cmd.append(checkout_dir)
+                local(clone_cmd, quiet=True)
                 if tree:
-                    checkout_cmd = ' && git checkout %s' % tree
+                    local(['git', 'checkout', tree], dir=checkout_dir)
 
-                local('git clone {repository_url} --recurse-submodules --shallow-submodules {checkout_dir} && cd {checkout_dir} {checkout_cmd}'.
-                      format(repository_url=repository_url,
-                             checkout_dir=shlex.quote(checkout_dir),
-                             checkout_cmd=checkout_cmd),
-                      quiet=True)
         else:  # dir already exists
             if os.path.exists(os.path.join(checkout_dir, '.git')):  # this is a git repo
                 has_local_changes = True  # default to True for safety
                 if not unsafe_mode:
                     local_changes = str(local(
-                        command='cd %s && git status -sbuno' % shlex.quote(checkout_dir),
+                        command='git status -sbuno',
                         quiet=True,
                         echo_off=True,
+                        dir=checkout_dir,
                     )).strip().splitlines()
 
                     # result greater than 1 indicates local modifications are present
                     has_local_changes = len(local_changes) > 1
 
                 if unsafe_mode or not has_local_changes:
-                    checkout_cmd = ''
+                    checkout_cmd = None
                     if tree:
                         checkout_branch = tree
                         if not is_tag and not is_revision:
                             checkout_branch = 'origin/%s' % tree
 
-                        checkout_cmd = '&& git checkout -f %s' % checkout_branch
+                        checkout_cmd = 'git checkout -f %s' % checkout_branch
 
-                    local('cd {checkout_dir} && git fetch -a origin {checkout_cmd} && git submodule update --init'.
-                          format(checkout_dir=shlex.quote(checkout_dir),
-                                 checkout_cmd=checkout_cmd),
-                          quiet=True)
+                    local('git fetch -a origin', dir=checkout_dir, quiet=True)
+                    if checkout_cmd:
+                        local(checkout_cmd, dir=checkout_dir, quiet=True)
+                    local('git submodule update --init', dir=checkout_dir, quiet=True)
                 else:
                     fail('git_checkout() failed: local modifications present and safe_mode is enabled')
 

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -65,22 +65,23 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
 
     # Command string builder with common argument logic
     def build_helm_command(command, auth=None, version=None):
-        command = 'helm ' + command
+        args = ['helm']
+        args.extend(command)
 
         if auth != None:
             username, password = auth
             if username != '':
-                command += ' --username %s' % shlex.quote(username)
+                args.extend(['--username', username])
             if password != '':
-                command += ' --password %s' % shlex.quote(password)
+                args.extend(['--password', password])
 
         if version != None and version != 'latest':
-            command += ' --version %s' % shlex.quote(version)
+            args.extend(['--version', version])
 
-        return command
+        return args
 
     def fetch_chart_details(chart, repo_name, auth, version):
-        command = build_helm_command('search repo %s/%s --output yaml' % (shlex.quote(repo_name), shlex.quote(chart)), None, version)
+        command = build_helm_command(['search', 'repo', '%s/%s' % (repo_name, chart), '--output', 'yaml'], None, version)
         results = decode_yaml(local(command, quiet=True))
 
         return results[0] if len(results) > 0 else None
@@ -121,7 +122,7 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
 
         if local_helm_repo == None:
             # Unaware of repo, add it
-            repo_command = 'repo add %s %s' % (shlex.quote(repo_name), shlex.quote(repo_url))
+            repo_command = ['repo', 'add', repo_name, repo_url]
             # Add authentication for adding the repository if credentials are provided
             output = str(local(build_helm_command(repo_command, (username, password)), quiet=True)).rstrip('\n')
             if 'already exists' not in output: # repo was added
@@ -129,7 +130,7 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
         else:
             # Helm is already aware of the chart, update repo (unfortunately you cannot specify a single repo)
             if _get_skip() != 'True':
-                repo_command = 'repo update'
+                repo_command = ['repo', 'update']
                 local(build_helm_command(repo_command), quiet=True)
                 _set_skip('True')
 
@@ -160,7 +161,7 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
 
     if needs_pull:
         # -------- commands
-        pull_command = 'pull %s/%s --untar --destination %s' % (repo_name, chart, shlex.quote(pull_target))
+        pull_command = ['pull', '%s/%s' % (repo_name, chart), '--untar', '--destination', pull_target]
 
         # ======== Perform Installation
         if cached_chart_exists:


### PR DESCRIPTION
For windows compatibility. Fixes #339.
