### PR TITLE
nerdctl: extension for containerd in-cluster builds

### DIFF
--- a/kim/README.md
+++ b/kim/README.md
@@ -7,7 +7,7 @@ Use [kim](https://github.com/rancher/kim) to build images directly within your K
 
 ⚠️ **DEPRECATED**
 
-Rancher Desktop users should switch to [`nerdctl_build`](https://github.com/tilt-dev/tilt-extensions/tree/master/cancel) if using the `containerd` runtime (default) or Tilt's built-in `docker_build` if using the `moby` (Docker) runtime.
+Rancher Desktop users should switch to [`nerdctl_build`](https://github.com/tilt-dev/tilt-extensions/tree/master/cancel) if using the `containerd` runtime (default) or Tilt's built-in `docker_build` if using the `dockerd (moby)` runtime.
 
 ## Functions
 ### `kim_build(ref: str, context: str, ignore: List[str] = None, extra_flags: List[str] = None, **kwargs)`

--- a/kim/README.md
+++ b/kim/README.md
@@ -7,7 +7,7 @@ Use [kim](https://github.com/rancher/kim) to build images directly within your K
 
 ⚠️ **DEPRECATED**
 
-Rancher Desktop users should switch to [`nerdctl_build`](https://github.com/tilt-dev/tilt-extensions/tree/master/cancel) if using the `containerd` runtime (default) or Tilt's built-in `docker_build` if using the `dockerd (moby)` runtime.
+Rancher Desktop users should switch to [`nerdctl_build`](https://github.com/tilt-dev/tilt-extensions/tree/master/nerdctl) if using the `containerd` runtime (default) or Tilt's built-in `docker_build` if using the `dockerd (moby)` runtime.
 
 ## Functions
 ### `kim_build(ref: str, context: str, ignore: List[str] = None, extra_flags: List[str] = None, **kwargs)`

--- a/kim/README.md
+++ b/kim/README.md
@@ -3,6 +3,12 @@ Author: [Lasse Højgaard](https://github.com/lhotrifork)
 
 Use [kim](https://github.com/rancher/kim) to build images directly within your Kubernetes cluster.
 
+## Status
+
+⚠️ **DEPRECATED**
+
+Rancher Desktop users should switch to [`nerdctl_build`](https://github.com/tilt-dev/tilt-extensions/tree/master/cancel) if using the `containerd` runtime (default) or Tilt's built-in `docker_build` if using the `moby` (Docker) runtime.
+
 ## Functions
 ### `kim_build(ref: str, context: str, ignore: List[str] = None, extra_flags: List[str] = None, **kwargs)`
 - **`ref`**: The name of the image to build. Must match the image

--- a/nerdctl/README.md
+++ b/nerdctl/README.md
@@ -67,6 +67,8 @@ None
 
 ### `containerd` Address
 
+If your `containerd` socket is located in a non-default location, you'll need to provide the address to Tilt.
+
 Set the `CONTAINERD_ADDRESS` in your shell before launching Tilt:
 
 ```bash
@@ -86,6 +88,14 @@ if 'CONTAINERD_ADDRESS' not in os.environ:
         )
     )
 ```
+
+## Troubleshooting
+
+### `nerdctl: command not found` / `Custom build command failed: exit status 127`
+
+Tilt cannot find `nerdctl` in your `PATH`.
+
+Open `Rancher Desktop > Preferences > Supporting Utilities`, check the box for `nerdctl`, and retry your build in Tilt.
 
 [nerdctl]: https://github.com/containerd/nerdctl
 [containerd]: https://github.com/containerd/containerd

--- a/nerdctl/README.md
+++ b/nerdctl/README.md
@@ -1,0 +1,92 @@
+# `nerdctl` Extension
+
+Authors:
+
+* [Milas Bowman](https://github.com/milas)
+
+Use [nerdctl][] to build Tilt images for local clusters that use [containerd][] like Rancher Desktop.
+
+Images are built directly into the container runtime avoiding the need to push to a local registry.
+
+## Example Usage
+
+```python
+load('ext://nerdctl', 'nerdctl_build')
+
+nerdctl_build(
+    ref='registry.example.com/my-image',
+    context='.',
+)
+```
+
+## API
+
+### `nerdctl_build()`
+
+The API closely mirrors the [`docker_build`][docker_build] API.
+
+Images will be built in the `k8s.io` namespace so that they will be immediately usable by the cluster.
+
+```python
+def nerdctl_build(
+    ref: str,
+    context: str,
+    build_args: Dict[str, str]={},
+    dockerfile: str=None,
+    dockerfile_contents: str=None,
+    live_update: List[LiveUpdateStep]=[],
+    match_in_env_vars: bool=False,
+    ignore: Union[str, List[str]]=[],
+    entrypoint: Union[str, List[str]]=[],
+    target: str='',
+    ssh: Union[str, List[str]]='',
+    secret: Union[str, List[str]]='',
+    extra_tag: Union[str, List[str]]='',
+    cache_from: Union[str, List[str]]=[],
+    platform: str='',
+):
+    pass
+```
+
+### Differences from `docker_build()`
+
+Due to differences between containerd and Docker/moby as well as limitations in what Tilt allows for custom image builds, not all arguments or features can be supported.
+
+#### Unsupported Arguments in `nerdctl_build()`
+
+* `only`: Not supported by Tilt for custom builds
+* `network`: Not supported by `nerdctl`
+* `container_args`: Not supported by Tilt for custom builds
+* `pull`: Not supported by `nerdctl`
+
+#### Extra Arguments in `nerdctl_build()`
+
+None
+
+## Configuration
+
+### `containerd` Address
+
+Set the `CONTAINERD_ADDRESS` in your shell before launching Tilt:
+
+```bash
+CONTAINERD_ADDRESS="${XDG_RUNTIME_DIR}/containerd/containerd.sock" tilt up
+```
+
+Alternatively, set it in your `Tiltfile` with `os.putenv`:
+
+```python
+if 'CONTAINERD_ADDRESS' not in os.environ:
+    os.putenv(
+        'CONTAINERD_ADDRESS',
+        os.path.join(
+            os.getenv('XDG_RUNTIME_DIR'),
+            'containerd',
+            'containerd.sock'
+        )
+    )
+```
+
+[nerdctl]: https://github.com/containerd/nerdctl
+[containerd]: https://github.com/containerd/containerd
+[docker_build]: https://docs.tilt.dev/api.html#api.docker_build

--- a/nerdctl/Tiltfile
+++ b/nerdctl/Tiltfile
@@ -1,0 +1,107 @@
+def _quote(v):
+    if os.name == 'nt':
+        return v
+    return shlex.quote(v)
+
+def _env_key(ref):
+    out = 'NERDCTL_DF_'
+    for c in ref.elems():
+        if c.isalnum():
+            out += c
+        else:
+            out += '_'
+    return out
+
+def nerdctl_build(
+    ref,
+    context,
+    build_args={},
+    dockerfile=None,
+    dockerfile_contents=None,
+    live_update=[],
+    match_in_env_vars=False,
+    ignore=[],
+    entrypoint=[],
+    target='',
+    ssh='',
+    secret='',
+    extra_tag='',
+    cache_from=[],
+    platform='',
+):
+    cmd = ['nerdctl']
+
+    cmd += ['--namespace', 'k8s.io']
+
+    cmd += ['build']
+
+    for arg, value in build_args.items():
+        cmd += ['--build-arg', arg + '=' + value]
+
+    if dockerfile:
+        cmd += ['-f', dockerfile]
+    elif dockerfile_contents:
+        cmd += ['-f', '-']
+
+    if target:
+        cmd += ['--target', target]
+
+    if ssh:
+        cmd += ['--ssh', ssh]
+
+    if secret:
+        cmd += ['--secret', secret]
+
+    if extra_tag:
+        if type(extra_tag) == 'string':
+            cmd += ['-t', extra_tag]
+        else:
+            for t in extra_tag:
+                cmd += ['-t', t]
+
+    if cache_from:
+        if type(cache_from) == 'string':
+            cmd += ['--cache-from', cache_from]
+        else:
+            for v in cache_from:
+                cmd += ['--cache-from', v]
+
+    # add the expected ref arg _after_ quoting since we actually
+    # want shell expansion here and quoting will turn this into
+    # a literal
+    if os.name == 'nt':
+        cmd += ['-t', '%%EXPECTED_REF%%']
+    else:
+        cmd += ['-t', '"${EXPECTED_REF}"']
+
+    cmd += [_quote(context)]
+    cmd = ' '.join(cmd)
+
+    kwargs = {}
+    if dockerfile_contents:
+        # TODO(milas): this should use `env` arg, but custom_build
+        #   doesn't currently support that
+        env_key = _env_key(ref)
+        os.putenv(env_key, dockerfile_contents)
+        base_cmd = cmd
+        cmd = 'echo "${{{env_key}}}" | {cmd}'.format(
+            env_key=env_key,
+            cmd=base_cmd,
+        )
+        kwargs['command_bat'] = '(cmd /v:on /c echo !{env_key}!) | {cmd}'.format(
+            env_key=env_key,
+            cmd=base_cmd
+        )
+
+    custom_build(
+        ref=ref,
+        command=cmd,
+        deps=[context],
+        disable_push=True,
+        skips_local_docker=True,
+        live_update=live_update,
+        match_in_env_vars=match_in_env_vars,
+        ignore=ignore,
+        entrypoint=entrypoint,
+        **kwargs
+    )

--- a/nerdctl/Tiltfile
+++ b/nerdctl/Tiltfile
@@ -66,6 +66,8 @@ def nerdctl_build(
             for v in cache_from:
                 cmd += ['--cache-from', v]
 
+    cmd = [_quote(x) for x in cmd]
+
     # add the expected ref arg _after_ quoting since we actually
     # want shell expansion here and quoting will turn this into
     # a literal
@@ -74,6 +76,8 @@ def nerdctl_build(
     else:
         cmd += ['-t', '"${EXPECTED_REF}"']
 
+    # nerdctl only supports context as a positional arg,
+    # so it needs to go last and be manually quoted
     cmd += [_quote(context)]
     cmd = ' '.join(cmd)
 

--- a/nerdctl/test/Dockerfile
+++ b/nerdctl/test/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox
+WORKDIR /app
+ADD . .
+ENTRYPOINT ./main.sh

--- a/nerdctl/test/Tiltfile
+++ b/nerdctl/test/Tiltfile
@@ -1,0 +1,6 @@
+# -*- mode: Python -*-
+
+load('../Tiltfile', 'nerdctl_build')
+
+nerdctl_build('example-nerdctl-image', '.')
+k8s_yaml('deployment.yaml')

--- a/nerdctl/test/deployment.yaml
+++ b/nerdctl/test/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-nerdctl
+  labels:
+    app: example-nerdctl
+spec:
+  selector:
+    matchLabels:
+      app: example-nerdctl
+  template:
+    metadata:
+      labels:
+        app: example-nerdctl
+    spec:
+      containers:
+      - name: example-nerdctl
+        image: example-nerdctl-image
+        ports:
+        - containerPort: 8000

--- a/nerdctl/test/index.html
+++ b/nerdctl/test/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <body style="font-size: 30px; font-family: sans-serif; margin: 0;">
+    <div style="display: flex; flex-direction: column; width: 100vw; height: 100vh; align-items: center; justify-content: center;">
+      <img src="pets.png" style="max-width: 30vw; max-height: 30vh;">
+      <div>Hello cats!</div>
+    </div>
+  </body>
+</html>

--- a/nerdctl/test/main.sh
+++ b/nerdctl/test/main.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Serving files on port 8000"
+busybox httpd -f -p 8000

--- a/nerdctl/test/test.sh
+++ b/nerdctl/test/test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -ex
+
+cd "$(dirname "$0")"
+
+tilt ci
+tilt down

--- a/test.sh
+++ b/test.sh
@@ -11,6 +11,13 @@ SKIPPED_TESTS=(
 # TODO(milas): the prometheus resources need more CPU than
 #   our CI KIND cluster can provide
 coreos_prometheus/test/test.sh
+
+# TODO(milas): we use kind w/ containerd in CI, but there's
+#   not an easy to get access to the containerd socket. You
+#   can still run this manually on a machine with Rancher
+#   Desktop in containerd mode.
+nerdctl/test/test.sh
+
 # TODO(nick): Currently it's a PITA to run podman in CI,
 # so we've turned this off. You can still run it manually
 # on a machine with podman installed.


### PR DESCRIPTION
This is primarily useful for Rancher Desktop users at the moment
and supersedes the `kim` extension.