### PR TITLE
circleci: add a space to the ci working dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jobs:
       - run: make shellcheck
 
   test:
+    # A common error is to build an extension that doesn't properly handle
+    # spaces in paths, which is common on macOS (/Application Support/)
+    working_directory: ~/tilt extensions
     docker:
       - image: gcr.io/windmill-public-containers/tilt-extensions-ci@sha256:d28e3730cf8bfd8be86ec7d67b94bc163529e10018cb3c4d8ea8ecade58e4cad
 

--- a/tilt_inspector/Tiltfile
+++ b/tilt_inspector/Tiltfile
@@ -11,8 +11,8 @@ def tilt_inspector(port=11351):
   local_resource(
     name="tilt:inspector",
     deps=[],
-    cmd='cd %s && yarn install' % _dir,
+    cmd='cd %s && yarn install' % shlex.quote(_dir),
     serve_env={'TILT_INSPECTOR_PORT': '%d' % port},
-    serve_cmd='cd %s && yarn run tilt-inspector' % _dir,
+    serve_cmd='cd %s && yarn run tilt-inspector' % shlex.quote(_dir),
     readiness_probe=probe(http_get=http_get_action(port=port)),
     links=['http://localhost:%d/' % port])


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/space:

f158d9e6f9b5facf07c866d95d1409a3f178c49a (2022-02-17 19:12:02 -0500)
circleci: add a space to the ci working dir

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics