### PR TITLE
docker_run: new extension/function to run standalone containers

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -29,3 +29,9 @@ RUN curl -sSL "https://github.com/buildpacks/pack/releases/download/v0.21.1/pack
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
   apt update && apt install -y yarn
+
+# install docker-compose
+ARG DOCKER_COMPOSE_VERSION=v2.2.3
+RUN curl -fL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s | tr '[A-Z]' '[a-z]')-$(uname -m)" -o /usr/local/bin/docker-compose \
+  && chmod a+x /usr/local/bin/docker-compose \
+  && docker-compose version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   validate:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-extensions-ci@sha256:d28e3730cf8bfd8be86ec7d67b94bc163529e10018cb3c4d8ea8ecade58e4cad
+      - image: gcr.io/windmill-public-containers/tilt-extensions-ci@sha256:521e0697acc3dde27cb39d3052dfe5434c083fc99e1ffa0119853a7de0090715
 
     steps:
       - checkout
@@ -11,7 +11,7 @@ jobs:
 
   shellcheck:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-extensions-ci@sha256:d28e3730cf8bfd8be86ec7d67b94bc163529e10018cb3c4d8ea8ecade58e4cad
+      - image: gcr.io/windmill-public-containers/tilt-extensions-ci@sha256:521e0697acc3dde27cb39d3052dfe5434c083fc99e1ffa0119853a7de0090715
 
     steps:
       - checkout
@@ -19,7 +19,7 @@ jobs:
 
   test:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-extensions-ci@sha256:d28e3730cf8bfd8be86ec7d67b94bc163529e10018cb3c4d8ea8ecade58e4cad
+      - image: gcr.io/windmill-public-containers/tilt-extensions-ci@sha256:521e0697acc3dde27cb39d3052dfe5434c083fc99e1ffa0119853a7de0090715
 
     steps:
       - setup_remote_docker:

--- a/docker_run/README.md
+++ b/docker_run/README.md
@@ -78,22 +78,7 @@ docker_compose_yaml(
 
 Build Compose YAML for a single service with the given image and parameters. The returned YAML will contain a `services` key with a single defined service.
 
-- `image`: The image name to run
-- `command`: An override for the command to run, either a string or list of strings.
-- `container_name`: An override the container name
-- `env`: Environment variables to set, a dict with string values.
-- `env_file`: An environment file to use. Must be a path to a file or a list of paths.
-- `entrypoint`: An override for the image entrypoint.
-- `expose`: A list of ports to be exposed.
-- `links`: A list of network links.
-- `networks`: A list of networks to attach.
-- `ports`: A list of ports to be forwarded, either a list of strings or port specs.
-  See [the compose spec](https://github.com/compose-spec/compose-spec/blob/master/spec.md#ports) for details.
-- `privileged`: Whether to run the container in privileged mode, a boolean.
-- `restart`: Restart spec, one of `(no|always|on-failure|unless-stopped)`.
-- `runtime`: The name of the runtime to use.
-- `volumes`: A list of volumes to attach.
-- `**kwargs`: Extra fields added to the compose spec.
+All arguments are identical to those listed above for `docker_run`.
 
 ## Examples
 
@@ -102,8 +87,8 @@ Build Compose YAML for a single service with the given image and parameters. The
 ```python
 load('ext://docker_run, 'docker_run')
 
-# Create a redis deployment with a readiness probe
-docker_run('redis')
+# Run a redis container and publish port 6379
+docker_run('redis', ports='6379')
 ```
 
 # Deploy a custom built image
@@ -117,7 +102,7 @@ FROM nginx:latest
 COPY . /usr/share/nginx/html
 """)
 
-# Deploy the image and expose it as a service on port 80
+# Deploy the image and publish port 80
 docker_run('web', ports='80')
 ```
 

--- a/docker_run/README.md
+++ b/docker_run/README.md
@@ -1,0 +1,126 @@
+# Docker Run
+
+Author: [Nick Sieger](https://github.com/nicksieger)
+
+Run a single docker container, as one would with `docker run`.
+
+The difference between this extension and a simple `docker run` command in a `local_resource` is that `docker_run` allows Tilt to manage the image build and inject the latest content-based tag. This is accomplished using Tilt's built-in `docker_compose` orchestration. `docker_run` builds compose YAML and hands it over to `docker_compose`.
+
+
+## Functions
+
+### docker_run
+
+```
+docker_run(
+  image,
+  command=None,
+  container_name=None,
+  env=None,
+  env_file=None,
+  entrypoint=None,
+  expose=[], 
+  links=[],
+  networks=[],
+  ports=[],
+  privileged=False,
+  restart=None,
+  runtime=None,
+  volumes=[],
+  **kwargs
+)
+```
+
+Run a single docker container, as one would with `docker run`.
+
+Simulates `docker run` using Tilt's `docker_compose` orchestrator with inline
+Compose YAML built by `docker_compose_yaml`.
+
+- `image`: The image name to run
+- `command`: An override for the command to run, either a string or list of strings.
+- `container_name`: An override the container name
+- `env`: Environment variables to set, a dict with string values.
+- `env_file`: An environment file to use. Must be a path to a file or a list of paths.
+- `entrypoint`: An override for the image entrypoint.
+- `expose`: A list of ports to be exposed.
+- `links`: A list of network links.
+- `networks`: A list of networks to attach.
+- `ports`: A list of ports to be forwarded, either a list of strings or port specs.
+  See [the compose spec](https://github.com/compose-spec/compose-spec/blob/master/spec.md#ports) for details.
+- `privileged`: Whether to run the container in privileged mode, a boolean.
+- `restart`: Restart spec, one of `(no|always|on-failure|unless-stopped)`.
+- `runtime`: The name of the runtime to use.
+- `volumes`: A list of volumes to attach.
+- `**kwargs`: Extra fields added to the compose spec.
+
+
+### docker_compose_yaml
+
+```
+docker_compose_yaml(
+  image,
+  command=None,
+  container_name=None,
+  env=None,
+  env_file=None,
+  entrypoint=None,
+  expose=[], 
+  links=[],
+  networks=[],
+  ports=[],
+  privileged=False,
+  restart=None,
+  runtime=None,
+  volumes=[],
+  **kwargs
+): Blob
+```
+
+Build Compose YAML for a single service with the given image and parameters. The returned YAML will contain a `services` key with a single defined service.
+
+- `image`: The image name to run
+- `command`: An override for the command to run, either a string or list of strings.
+- `container_name`: An override the container name
+- `env`: Environment variables to set, a dict with string values.
+- `env_file`: An environment file to use. Must be a path to a file or a list of paths.
+- `entrypoint`: An override for the image entrypoint.
+- `expose`: A list of ports to be exposed.
+- `links`: A list of network links.
+- `networks`: A list of networks to attach.
+- `ports`: A list of ports to be forwarded, either a list of strings or port specs.
+  See [the compose spec](https://github.com/compose-spec/compose-spec/blob/master/spec.md#ports) for details.
+- `privileged`: Whether to run the container in privileged mode, a boolean.
+- `restart`: Restart spec, one of `(no|always|on-failure|unless-stopped)`.
+- `runtime`: The name of the runtime to use.
+- `volumes`: A list of volumes to attach.
+- `**kwargs`: Extra fields added to the compose spec.
+
+## Examples
+
+### Deploy an image from Docker Hub
+
+```python
+load('ext://docker_run, 'docker_run')
+
+# Create a redis deployment with a readiness probe
+docker_run('redis')
+```
+
+# Deploy a custom built image
+
+```python
+load('ext://docker_run, 'docker_run')
+
+# Build a custom nginx image
+docker_build('web', './assets', dockerfile_contents="""
+FROM nginx:latest
+COPY . /usr/share/nginx/html
+""")
+
+# Deploy the image and expose it as a service on port 80
+docker_run('web', ports='80')
+```
+
+## Caveats
+
+- This extension doesn't do any validation to confirm that any arguments are valid Docker or Docker Compose parameters.

--- a/docker_run/Tiltfile
+++ b/docker_run/Tiltfile
@@ -1,0 +1,104 @@
+
+def docker_compose_yaml(image, command=None, container_name=None, env=None, env_file=None,
+                        entrypoint=None, expose=[], links=[], networks=[], ports=[], privileged=False,
+                        restart=None, runtime=None, volumes=[], **kwargs):
+    """Build Compose YAML for a single service with the given image and parameters.
+
+    Args:
+      image: The image name to run
+      command: An override for the command to run, either a string or list of strings.
+      container_name: An override the container name
+      env: Environment variables to set, a dict with string values.
+      env_file: An environment file to use. Must be a path to a file or a list of paths.
+      entrypoint: An override for the image entrypoint.
+      expose: A list of ports to be exposed.
+      links: A list of network links.
+      networks: A list of networks to attach.
+      ports: A list of ports to be forwarded, either a list of strings or port specs.
+         See https://github.com/compose-spec/compose-spec/blob/master/spec.md#ports for details.
+      privileged: Whether to run the container in privileged mode, a boolean.
+      restart: Restart spec, one of (no|always|on-failure|unless-stopped).
+      runtime: The name of the runtime to use.
+      volumes: A list of volumes to attach.
+    """
+    def ensure_list(obj):
+        if type(obj) == 'list':
+            return obj
+        return [obj]
+
+    svc = {'image': image}
+
+    if command:
+        svc['command'] = command
+
+    if container_name:
+        svc['container_name'] = container_name
+
+    if env:
+        svc['environment'] = env
+
+    if env_file:
+        svc['env_file'] = env_file
+
+    if entrypoint:
+        svc['entrypoint'] = entrypoint
+
+    if expose:
+        svc['expose'] = ensure_list(expose)
+
+    if links:
+        svc['links'] = ensure_list(links)
+
+    if networks:
+        svc['networks'] = ensure_list(networks)
+
+    if ports:
+        svc['ports'] = ensure_list(ports)
+
+    if privileged:
+        svc['privileged'] = privileged
+
+    if restart:
+        svc['restart'] = restart
+
+    if runtime:
+        svc['runtime'] = runtime
+
+    if volumes:
+        svc['volumes'] = ensure_list(volumes)
+
+    if len(kwargs) > 0:
+        svc.update(kwargs)
+
+    name = image.replace(':', '_').replace('/','_')
+    return encode_yaml({'services': {name: svc}})
+
+
+def docker_run(image, command=None, container_name=None, env=None, env_file=None,
+               entrypoint=None, expose=[], links=[], networks=[], ports=[], privileged=False,
+               restart=None, runtime=None, volumes=[], **kwargs):
+    """Run a single docker container, as one would with `docker run`.
+
+    Simulates `docker run` using Tilt's `docker_compose` orchestrator with inline
+    Compose YAML built by `docker_compose_yaml`.
+
+    Args:
+      image: The image name to run
+      command: An override for the command to run, either a string or list of strings.
+      container_name: An override the container name
+      env: Environment variables to set, a dict with string values.
+      env_file: An environment file to use. Must be a path to a file or a list of paths.
+      entrypoint: An override for the image entrypoint.
+      expose: A list of ports to be exposed.
+      links: A list of network links.
+      networks: A list of networks to attach.
+      ports: A list of ports to be forwarded, either a list of strings or port specs.
+         See https://github.com/compose-spec/compose-spec/blob/master/spec.md#ports for details.
+      privileged: Whether to run the container in privileged mode, a boolean.
+      restart: Restart spec, one of (no|always|on-failure|unless-stopped).
+      runtime: The name of the runtime to use.
+      volumes: A list of volumes to attach.
+    """
+    docker_compose(docker_compose_yaml(image, command, container_name, env, env_file, entrypoint,
+                                       expose, links, networks, ports, privileged,
+                                       restart, runtime, volumes))

--- a/docker_run/test/Tiltfile
+++ b/docker_run/test/Tiltfile
@@ -1,0 +1,16 @@
+load('../Tiltfile', 'docker_compose_yaml', 'docker_run')
+
+def assert_equal(x, y):
+    if x != y:
+        fail("Expected '{}' to equal '{}'".format(y, x))
+
+redis = decode_yaml(docker_compose_yaml('redis', ports=['6379:6379']))
+
+assert_equal('redis', redis['services']['redis']['image'])
+assert_equal(['6379:6379'], redis['services']['redis']['ports'])
+
+docker_run('redis', ports=['6379:6379'])
+docker_run('nginx', ports=['8008:80'])
+
+local_resource('redis-test', ['bash', '-xc', 'sleep 1 && result=$(echo -ne "PING\r\n" | nc localhost 6379 2>&1) && [ "${result:1:4}" = "PONG" ]'], resource_deps=['redis'])
+local_resource('nginx-test', 'sleep 1 && curl -sf http://localhost:8008 | grep "Welcome to nginx"', resource_deps=['nginx'])

--- a/docker_run/test/Tiltfile
+++ b/docker_run/test/Tiltfile
@@ -12,5 +12,6 @@ assert_equal(['6379:6379'], redis['services']['redis']['ports'])
 docker_run('redis', ports=['6379:6379'])
 docker_run('nginx', ports=['8008:80'])
 
-local_resource('redis-test', ['bash', '-xc', 'sleep 1 && result=$(echo -ne "PING\r\n" | nc localhost 6379 2>&1) && [ "${result:1:4}" = "PONG" ]'], resource_deps=['redis'])
-local_resource('nginx-test', 'sleep 1 && curl -sf http://localhost:8008 | grep "Welcome to nginx"', resource_deps=['nginx'])
+wait_for_port='while ! nc -z localhost %s; do sleep 1; done && '
+local_resource('redis-test', ['bash', '-xc', (wait_for_port % '6379') + 'result=$(echo -ne "PING\r\n" | nc localhost 6379 2>&1) && [ "${result:1:4}" = "PONG" ]'], resource_deps=['redis'])
+local_resource('nginx-test', (wait_for_port % '8008') + 'curl -sf http://localhost:8008 | grep "Welcome to nginx"', resource_deps=['nginx'])

--- a/docker_run/test/Tiltfile
+++ b/docker_run/test/Tiltfile
@@ -12,6 +12,16 @@ assert_equal(['6379:6379'], redis['services']['redis']['ports'])
 docker_run('redis', ports=['6379:6379'])
 docker_run('nginx', ports=['8008:80'])
 
+# CI/Remote docker, use ctlptl-portforward-service to forward ports
+if os.environ.get('DOCKER_HOST', None):
+    for port in ('6379', '8008'):
+        local_resource('forward-%s' % port,
+                       serve_cmd=[
+                           'socat',
+                           'TCP-LISTEN:%s,reuseaddr,fork' % port,
+                           "EXEC:'docker exec -i ctlptl-portforward-service socat STDIO TCP:localhost:%s'" % port
+                       ])
+
 wait_for_port='while ! nc -z localhost %s; do sleep 1; done && '
-local_resource('redis-test', ['bash', '-xc', (wait_for_port % '6379') + 'result=$(echo -ne "PING\r\n" | nc localhost 6379 2>&1) && [ "${result:1:4}" = "PONG" ]'], resource_deps=['redis'])
+local_resource('redis-test', ['bash', '-xc', (wait_for_port % '6379') + 'echo -ne "PING\r\nQUIT\r\n" | nc localhost 6379 2>&1 | grep "+PONG"'], resource_deps=['redis'])
 local_resource('nginx-test', (wait_for_port % '8008') + 'curl -sf http://localhost:8008 | grep "Welcome to nginx"', resource_deps=['nginx'])

--- a/docker_run/test/test.sh
+++ b/docker_run/test/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")"
+
+set -ex
+
+tilt ci "$@"
+tilt down


### PR DESCRIPTION
With simultaneous docker compose+k8s orchestration now available, I think the time is right for this to exist, to allow people to more idiomatically manage simple docker container builds+runs within the Tiltfile.
