### PR TITLE
syncback: Fix paths not being properly applied

### DIFF
--- a/syncback/README.md
+++ b/syncback/README.md
@@ -38,6 +38,8 @@ You may also pass the following optional parameters:
 * **verbose (bool, optional)**: if true, print additional rsync information.
 * **labels (Union[str, List[str]], optional)**: used to group resources in the Web UI.
 
+Please note that `paths` and `ignore` are mutually exclusive, since the extension sets an exclude of `*` whenever `paths` is used.
+
 ### Example invocations
 1. Create a local resource called "syncback-js" which connects to the first pod of "deploy/frontend" (and the default container) and syncs "/app/package.json" and "/app/yarn.lock" to local directory "./frontend":
     ```python
@@ -61,7 +63,7 @@ You may also pass the following optional parameters:
 3. Create a local resource called "syncback-data" which connects to the first pod of "job/data-cron" syncs the contents of "/data" to the local cwd. Protect several files ("k8s.yaml", "config.json") that exist locally but not in the container (otherwise they would be deleted locally on sync):
     ```python
     syncback('syncback-data', 'job/data-cron',
-             [], '/data/',
+             '/data/',
              ignore=['k8s.yaml', 'config.json']
    )
     ```

--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -43,21 +43,26 @@ def syncback_command_args(k8s_object, src_dir, ignore=None, delete=False, paths=
                 fail('Found illegal path "{}": paths may not begin with / and must be relative to src_dir (because of rsync syntax rules)'.format(p))
 
     to_include = []
-    to_exclude = ignore
-    if not ignore:
-        to_exclude = []
+    to_exclude = []
 
-    if paths:
+    if paths and ignore:
+        fail('Paths and ignore are mutually exclusive.')
+    
+    if not paths:
+        if not ignore:
+            ignore = []
+
+        # Sync the entire src_dir except ignored items. Danger, Will Robinson! Exclude some stuff
+        # that may exist locally but not in your container so it
+        # doesn't get wiped out locally on your first sync
+        to_exclude = DEFAULT_EXCLUDES + ignore
+        to_exclude = ['--exclude={}***'.format(ex) for ex in to_exclude]
+
+    else:
         # TODO: if you're rsync-savvy you might want to do the wildcarding manually--
         #   give an option to turn off automatic +'***'
         to_include = ['--include={}***'.format(p) for p in paths]
-    else:
-        # Sync the entire src_dir. Danger, Will Robinson! Exclude some stuff
-        # that may exist locally but not in your container so it
-        # doesn't get wiped out locally on your first sync
-        to_exclude = DEFAULT_EXCLUDES + to_exclude
-
-    to_exclude = ['--exclude={}***'.format(ex) for ex in to_exclude]
+        to_exclude = ['--exclude="*"']
 
     # set remote name to a dummy name
     remote_name = 'syncback'
@@ -85,8 +90,8 @@ def syncback_command_args(k8s_object, src_dir, ignore=None, delete=False, paths=
     if delete:
         argv.append('--delete')
     argv.append('-T=/tmp/rsync.tilt')
-    argv.extend(to_include)
     argv.extend(to_exclude)
+    argv.extend(to_include)
     argv.append(remote_name + ':' + src_dir)
     argv.append(target_dir)
     return argv


### PR DESCRIPTION
The following snippet from the README would sync __everything__ from the container at the specified path:

```python
    syncback('syncback-data', 'job/data-cron',
             '/data/',
             ignore=['k8s.yaml', 'config.json']
   )
```

According to answers on [stack overflow](https://stackoverflow.com/questions/11111562/rsync-copy-over-only-certain-types-of-files-using-include-option) the include option overrides the exclude option, so it's mandatory to first exclude everything before including things.