### PR TITLE
syncback: fix paths/include/exclude behavior

### DIFF
--- a/syncback/README.md
+++ b/syncback/README.md
@@ -38,6 +38,8 @@ You may also pass the following optional parameters:
 * **verbose (bool, optional)**: if true, print additional rsync information.
 * **labels (Union[str, List[str]], optional)**: used to group resources in the Web UI.
 
+Please note that `paths` and `ignore` are mutually exclusive, since the extension sets an exclude of `*` whenever `paths` is used.
+
 ### Example invocations
 1. Create a local resource called "syncback-js" which connects to the first pod of "deploy/frontend" (and the default container) and syncs "/app/package.json" and "/app/yarn.lock" to local directory "./frontend":
     ```python
@@ -61,7 +63,7 @@ You may also pass the following optional parameters:
 3. Create a local resource called "syncback-data" which connects to the first pod of "job/data-cron" syncs the contents of "/data" to the local cwd. Protect several files ("k8s.yaml", "config.json") that exist locally but not in the container (otherwise they would be deleted locally on sync):
     ```python
     syncback('syncback-data', 'job/data-cron',
-             [], '/data/',
+             '/data/',
              ignore=['k8s.yaml', 'config.json']
    )
     ```

--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -43,21 +43,26 @@ def syncback_command_args(k8s_object, src_dir, ignore=None, delete=False, paths=
                 fail('Found illegal path "{}": paths may not begin with / and must be relative to src_dir (because of rsync syntax rules)'.format(p))
 
     to_include = []
-    to_exclude = ignore
-    if not ignore:
-        to_exclude = []
+    to_exclude = []
 
-    if paths:
+    if paths and ignore:
+        fail('Paths and ignore are mutually exclusive.')
+    
+    if not paths:
+        if not ignore:
+            ignore = []
+
+        # Sync the entire src_dir except ignored items. Danger, Will Robinson! Exclude some stuff
+        # that may exist locally but not in your container so it
+        # doesn't get wiped out locally on your first sync
+        to_exclude = DEFAULT_EXCLUDES + ignore
+        to_exclude = ['--exclude={}***'.format(ex) for ex in to_exclude]
+
+    else:
         # TODO: if you're rsync-savvy you might want to do the wildcarding manually--
         #   give an option to turn off automatic +'***'
         to_include = ['--include={}***'.format(p) for p in paths]
-    else:
-        # Sync the entire src_dir. Danger, Will Robinson! Exclude some stuff
-        # that may exist locally but not in your container so it
-        # doesn't get wiped out locally on your first sync
-        to_exclude = DEFAULT_EXCLUDES + to_exclude
-
-    to_exclude = ['--exclude={}***'.format(ex) for ex in to_exclude]
+        to_exclude = ['--exclude="*"']
 
     # set remote name to a dummy name
     remote_name = 'syncback'
@@ -85,8 +90,8 @@ def syncback_command_args(k8s_object, src_dir, ignore=None, delete=False, paths=
     if delete:
         argv.append('--delete')
     argv.append('-T=/tmp/rsync.tilt')
-    argv.extend(to_include)
     argv.extend(to_exclude)
+    argv.extend(to_include)
     argv.append(remote_name + ':' + src_dir)
     argv.append(target_dir)
     return argv

--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -42,8 +42,7 @@ def syncback_command_args(k8s_object, src_dir, ignore=None, delete=False, paths=
             if p.startswith('/'):
                 fail('Found illegal path "{}": paths may not begin with / and must be relative to src_dir (because of rsync syntax rules)'.format(p))
 
-    to_include = []
-    to_exclude = []
+    filters = []
 
     if paths and ignore:
         fail('Paths and ignore are mutually exclusive.')
@@ -56,13 +55,13 @@ def syncback_command_args(k8s_object, src_dir, ignore=None, delete=False, paths=
         # that may exist locally but not in your container so it
         # doesn't get wiped out locally on your first sync
         to_exclude = DEFAULT_EXCLUDES + ignore
-        to_exclude = ['--exclude={}***'.format(ex) for ex in to_exclude]
+        filters.extend(['--exclude={}***'.format(ex) for ex in to_exclude])
 
     else:
         # TODO: if you're rsync-savvy you might want to do the wildcarding manually--
         #   give an option to turn off automatic +'***'
-        to_include = ['--include={}***'.format(p) for p in paths]
-        to_exclude = ['--exclude="*"']
+        filters.extend(['--include={}***'.format(p) for p in paths])
+        filters.append('--exclude=*')
 
     # set remote name to a dummy name
     remote_name = 'syncback'
@@ -90,8 +89,7 @@ def syncback_command_args(k8s_object, src_dir, ignore=None, delete=False, paths=
     if delete:
         argv.append('--delete')
     argv.append('-T=/tmp/rsync.tilt')
-    argv.extend(to_exclude)
-    argv.extend(to_include)
+    argv.extend(filters)
     argv.append(remote_name + ':' + src_dir)
     argv.append(target_dir)
     return argv

--- a/syncback/test/Tiltfile
+++ b/syncback/test/Tiltfile
@@ -43,12 +43,12 @@ spec:
 cmd_button("Sync", "syncback-containers", syncback_command_args("deploy/syncback-containers", "/root/", target_dir=rsync, container="rsync", namespace="syncback-test"))
 local_resource("syncback-button", "tilt get uibuttons/Sync -o jsonpath='{.spec.location.componentID}' > syncback-button.txt && tilt get cmd/btn-Sync", resource_deps=["syncback-containers"])
 
-local_resource("python-file", "kubectl exec --namespace syncback-test -c python deploy/syncback-containers -- touch /root/main.py",   resource_deps=["syncback-containers"])
-local_resource("ruby-file",   "kubectl exec --namespace syncback-test -c ruby   deploy/syncback-containers -- touch /root/main.rb",   resource_deps=["syncback-containers"])
-local_resource("rsync-file",  "kubectl exec --namespace syncback-test -c rsync  deploy/syncback-containers -- touch /root/rsync.txt", resource_deps=["syncback-containers"])
+local_resource("python-file", "kubectl exec --namespace syncback-test -c python deploy/syncback-containers -- touch /root/main.py /root/example.txt",   resource_deps=["syncback-containers"])
+local_resource("ruby-file",   "kubectl exec --namespace syncback-test -c ruby   deploy/syncback-containers -- touch /root/main.rb /root/example.txt",   resource_deps=["syncback-containers"])
+local_resource("rsync-file",  "kubectl exec --namespace syncback-test -c rsync  deploy/syncback-containers -- touch /root/rsync.txt /root/example.txt", resource_deps=["syncback-containers"])
 
-syncback("python-syncback", "deploy/syncback-containers", "/root/", target_dir=python, container="python", namespace="syncback-test")
-syncback("ruby-syncback", "deploy/syncback-containers", "/root/", target_dir=ruby, container="ruby", namespace="syncback-test")
-syncback("rsync-syncback", "deploy/syncback-containers", "/root/", target_dir=rsync, container="rsync", namespace="syncback-test")
+syncback("python-syncback", "deploy/syncback-containers", "/root/", paths=['main.py'],  target_dir=python, container="python", namespace="syncback-test")
+syncback("ruby-syncback", "deploy/syncback-containers", "/root/",   paths=['main.rb'],  target_dir=ruby,   container="ruby",   namespace="syncback-test")
+syncback("rsync-syncback", "deploy/syncback-containers", "/root/",  paths=['rsync.txt'], target_dir=rsync, container="rsync",  namespace="syncback-test")
 
 local_resource("syncback-triggers", "tilt trigger python-syncback && tilt trigger ruby-syncback && tilt trigger rsync-syncback", resource_deps=["python-file", "ruby-file", "rsync-file"])

--- a/syncback/test/test.sh
+++ b/syncback/test/test.sh
@@ -6,8 +6,11 @@ set -ex
 tilt ci $@
 syncback_dir=$(cat syncback-dir.txt)
 test -f $syncback_dir/python/main.py
+test ! -f $syncback_dir/python/example.txt
 test -f $syncback_dir/ruby/main.rb
+test ! -f $syncback_dir/ruby/example.txt
 test -f $syncback_dir/rsync/rsync.txt
+test ! -f $syncback_dir/rsync/example.txt
 # Test that rsync was copied for containers that needed it
 kubectl exec -n syncback-test -c python deploy/syncback-containers -- sh -c "[ -f /bin/rsync.tilt ]"
 kubectl exec -n syncback-test -c ruby deploy/syncback-containers -- sh -c "[ -f /bin/rsync.tilt ]"


### PR DESCRIPTION
- Fix paths not being properly applied
- syncback: use `paths` in test
- syncback: fix use of paths/include/exclude
