### PR TITLE
helm_resource: Add port_forwards parameter for underlying k8s_resource

### DIFF
--- a/helm_resource/README.md
+++ b/helm_resource/README.md
@@ -30,7 +30,8 @@ def helm_resource(
     container_selector='',
     live_update=None,
     resource_deps=None,
-    labels=None):
+    labels=None,
+    port_forwards=[]):
   ...
 ```
 
@@ -76,6 +77,8 @@ chart. Must be the same length as `image_deps`.  There are two common patterns.
 `resource_deps`: Tilt resources to depend on. Useful for adding a dependency on a helm repo install.
 
 `labels`: Labels for categorizing the resource.
+
+`port_forwards`: Host port to connect to the pod. Takes the same form as `port_forwards` in [the `k8s_resource` command](https://docs.tilt.dev/api.html#api.k8s_resource).
 
 ### helm_repo
 

--- a/helm_resource/Tiltfile
+++ b/helm_resource/Tiltfile
@@ -107,10 +107,14 @@ helm uninstall %(namespace_arg)s %(release_name)s || true
     live_update=live_update)
 
   if resource_deps:
-    k8s_resource(name, resource_deps=resource_deps, port_forwards=port_forwards)
+    k8s_resource(name, resource_deps=resource_deps)
 
   if labels:
-    k8s_resource(name, labels=labels, port_forwards=port_forwards)
+    k8s_resource(name, labels=labels)
+
+  if len(port_forwards):
+    k8s_resource(name, port_forwards=port_forwards)
+
 
 def helm_repo(
     name,

--- a/helm_resource/Tiltfile
+++ b/helm_resource/Tiltfile
@@ -15,7 +15,8 @@ def helm_resource(
     container_selector='',
     live_update=None,
     resource_deps=None,
-    labels=None):
+    labels=None,
+    port_forwards=[]):
   """Installs a helm chart to a cluster.
 
   Args:
@@ -47,6 +48,7 @@ def helm_resource(
     resource_deps: Tilt resources to depend on. Useful for
       adding a dependency on a helm repo install.
     labels: Labels for categorizing the resource.
+    port_forwards: Host port to connect to the pod.
   """
 
   if not release_name:
@@ -105,10 +107,10 @@ helm uninstall %(namespace_arg)s %(release_name)s || true
     live_update=live_update)
 
   if resource_deps:
-    k8s_resource(name, resource_deps=resource_deps)
+    k8s_resource(name, resource_deps=resource_deps, port_forwards=port_forwards)
 
   if labels:
-    k8s_resource(name, labels=labels)
+    k8s_resource(name, labels=labels, port_forwards=port_forwards)
 
 def helm_repo(
     name,


### PR DESCRIPTION
We have an API server running using tilt that we wish to communicate with. The server listens on a specific port but the underlying `k8s_resource()` does not let us specify a port meaning that when we send requests we don't know which port to send them to. 

By adding the `port_forwards` argument we can optionally set the port on the `k8s_resource` function so we know to which port we can send requests to the server.