### PR TITLE
test: pin httpd 0.2.2 in the pack test

### DIFF
--- a/pack/test/Tiltfile
+++ b/pack/test/Tiltfile
@@ -9,7 +9,9 @@ pack(
   'example-httpd-image',
   deps=['httpd.conf', './htdocs'],
   builder='paketobuildpacks/builder:full',
-  buildpacks=['gcr.io/paketo-buildpacks/httpd'],
+  # 0.3.0 has a bug, see
+  # https://github.com/paketo-buildpacks/httpd/issues/297
+  buildpacks=['gcr.io/paketo-buildpacks/httpd:0.2.1'],
   live_update=[
     sync('./httpd.conf', '/workspace/httpd.conf'),
     sync('./htdocs', '/workspace/htdocs'),


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/pack2:

1dd2bc92c7eea2331cb1ab0ed5e66b1e258da13e (2022-03-18 17:55:33 -0400)
test: pin httpd 0.2.2 in the pack test
see:
https://github.com/paketo-buildpacks/httpd/issues/297

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics