### PR TITLE
fix: double percentage escape for nerdctl build

### DIFF
--- a/nerdctl/Tiltfile
+++ b/nerdctl/Tiltfile
@@ -72,7 +72,7 @@ def nerdctl_build(
     # want shell expansion here and quoting will turn this into
     # a literal
     if os.name == 'nt':
-        cmd += ['-t', '%%EXPECTED_REF%%']
+        cmd += ['-t', '{percent}EXPECTED_REF{percent}'.format(percent='%')]
     else:
         cmd += ['-t', '"${EXPECTED_REF}"']
 


### PR DESCRIPTION
Currently on windows this fails with 
```
error: failed to solve: failed to parse %example-nerdctl-image:tilt-build-1648718547%: invalid reference format
```

My suggestion is to use format to avoid single `%E` looking odd in code syntax.

Tested locally with `tilt ci`

```
[event: pod example-nerdctl-6464d5ddb4-zljd7] Container image "example-nerdctl-image:tilt-build-1648718665" already present on machine
SUCCESS. All workloads are healthy.
```