### PR TITLE
ci: bump remote docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - setup_remote_docker:
-          version: '20.10.6'
+          version: '20.10.11'
       - checkout
       - run: ctlptl create cluster kind --registry=ctlptl-registry && timeout -v -k 60s 20m ./test.sh
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/dockerversion:

c6c3156a4cb398ddfbb6feb4f4e12f45278019fe (2022-04-06 17:41:52 -0400)
ci: bump remote docker version

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics