### PR TITLE
test: disable pulumi test if no pulumi user

### DIFF
--- a/pulumi/test/Pulumi.dev.yaml
+++ b/pulumi/test/Pulumi.dev.yaml
@@ -1,2 +1,2 @@
 config:
-  busybox:image: localhost:38137/pulumi-helloworld-image:tilt-eda6a8a7c61b8530
+  busybox:image: localhost:42097/pulumi-helloworld-image:tilt-1ab394ac4c52874b

--- a/pulumi/test/test.sh
+++ b/pulumi/test/test.sh
@@ -4,6 +4,15 @@ cd "$(dirname "$0")"
 
 set -ex
 
+# Disable the pulumi test if no pulumi user.
+# Circleci won't inject our pulumi secrets for PRs, but
+# we still want to run other integration tests.
+PULUMI_USER=$(pulumi whoami --non-interactive)
+if [[ "$PULUMI_USER" == "" ]]; then
+    echo "No pulumi user. Skipping pulumi test"
+    exit 0
+fi
+
 # install pulumi deps
 yarn install
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/pulumi3:

a9f13f8c0ccd71912b8ec7564b393a68b7735825 (2022-04-06 17:57:17 -0400)
test: disable pulumi test if no pulumi user

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics