### PR TITLE
Revert "helm_resource: default our own namespaces (#376)"

### DIFF
--- a/helm_resource/helm-apply-helper.py
+++ b/helm_resource/helm-apply-helper.py
@@ -4,7 +4,6 @@
 # python3 helm-apply-helper.py ... [image config keys in order]
 
 import os
-import re
 import subprocess
 import sys
 
@@ -37,6 +36,7 @@ namespace = os.environ.get('NAMESPACE', '')
 if namespace:
   install_cmd.extend(['--namespace', namespace])
   get_cmd.extend(['--namespace', namespace])
+  kubectl_cmd.extend(['--namespace', namespace])
 
 install_cmd.extend([release_name, chart])
 get_cmd.extend([release_name])
@@ -46,30 +46,8 @@ print("Running cmd: %s" % install_cmd, file=sys.stderr)
 subprocess.check_call(install_cmd, stdout=sys.stderr)
 
 print("Running cmd: %s" % get_cmd, file=sys.stderr)
-out = subprocess.check_output(get_cmd).decode('utf-8')
-
-# We have to do namespace defaulting ourselves :(
-# See: https://github.com/tilt-dev/tilt-extensions/issues/374
-def add_default_namespace(yaml, namespace):
-  if not namespace:
-    return yaml
-
-  divider = '%s---%s' % (os.linesep, os.linesep)
-  resources = yaml.split(divider)
-
-  for i in range(len(resources)):
-    r = resources[i]
-    has_namespace = re.search("\n\\s+namespace:", r, re.MULTILINE)
-    if not has_namespace:
-      resources[i] = r.replace(
-        "\nmetadata:",
-        "\nmetadata:\n  namespace: %s" % namespace, 1)
-      print('defaulting %s' % r, file=sys.stderr)
-
-  return divider.join(resources)
+out = subprocess.check_output(get_cmd)
 
 print("Running cmd: %s" % kubectl_cmd, file=sys.stderr)
-completed = subprocess.run(
-  kubectl_cmd,
-  input=add_default_namespace(out, namespace).encode('utf-8'))
+completed = subprocess.run(kubectl_cmd, input=out)
 completed.check_returncode()


### PR DESCRIPTION
Hello @nicksieger,

Please review the following commits I made in branch nicks/rollback:

3b32df9296d3c3faeb84773858919c904d622312 (2022-04-07 10:00:18 -0400)
Revert "helm_resource: default our own namespaces (#376)"
This reverts commit 3f083db5fb35f7fbbf897731a49ce95c6711901a.

see https://github.com/tilt-dev/tilt-extensions/issues/379
for more info

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics