### PR TITLE
uibutton: only get timestamp once per run

### DIFF
--- a/uibutton/Tiltfile
+++ b/uibutton/Tiltfile
@@ -38,6 +38,26 @@ def _button(name, location, text='', icon=None, annotations={}, inputs=[]):
 
     return btn
 
+# shelling out to get the timestamp can be slow on windows, and we don't need *that* much precision, so cache it once per Tiltfile execution
+load('ext://global_vars', 'get_global', 'set_global')
+_cached_start_after_key = 'UI_BUTTON_CACHED_START_AFTER'
+set_global(_cached_start_after_key, '')
+
+def _start_after():
+    ts = get_global(_cached_start_after_key)
+    if ts == '':
+        ts = str(local(
+            # this is portable across coreutils/busybox/BSD
+            # note: it's missing fractional seconds because that's not available
+            # from strftime
+            command='date -u +"%Y-%m-%dT%H:%M:%S.000000Z"',
+            command_bat="powershell Get-Date (Get-Date).ToUniversalTime()\
+                -UFormat '+%Y-%m-%dT%H:%M:%S.000000Z'",
+            echo_off=True,
+            quiet=True)
+        ).rstrip('\r\n')
+        set_global(_cached_start_after_key, ts)
+    return ts
 
 def cmd_button(name, resource='', argv=[], text=None,
                location=LOCATION_RESOURCE, icon_name=None, icon_svg=None,
@@ -94,7 +114,7 @@ def cmd_button(name, resource='', argv=[], text=None,
             "args": argv,
             "dir": config.main_dir,
             "startOn": {
-                "startAfter": _now(),
+                "startAfter": _start_after(),
                 "uiButtons": [name],
             },
         }
@@ -107,20 +127,6 @@ def cmd_button(name, resource='', argv=[], text=None,
            | %s apply -f -' % (sys.executable,),
         env={'TILT_APPLY_YAML': str(encode_yaml_stream([button, cmd]))},
         echo_off=True)
-
-
-def _now():
-    return str(local(
-        # this is portable across coreutils/busybox/BSD
-        # note: it's missing fractional seconds because that's not available
-        # from strftime
-        command='date -u +"%Y-%m-%dT%H:%M:%S.000000Z"',
-        command_bat="powershell Get-Date (Get-Date).ToUniversalTime()\
-           -UFormat '+%Y-%m-%dT%H:%M:%S.000000Z'",
-        echo_off=True,
-        quiet=True)
-    ).rstrip('\r\n')
-
 
 def text_input(name, label='', default='', placeholder=''):
     return {


### PR DESCRIPTION
### Problem

Some windows users have reported that getting the timestamp (which we do to set the StartAfter field) can take seconds. That's annoyingly slow by itself, but we do it once per button, which makes it even worse.

### Solution

Only get the timestamp once per Tiltfile execution and use it for all uibuttons.
It'd still be good to add a native timestamp function to avoid shelling out, but that requires a Tilt release and raise the minimum required Tilt version for this extension, so we might as well do this as a short-term mitigation.