### PR TITLE
helm_resource: Add support for charts that use three fields for passing image references

### DIFF
--- a/helm_resource/README.md
+++ b/helm_resource/README.md
@@ -64,6 +64,10 @@ chart. Must be the same length as `image_deps`.  There are two common patterns.
   as a tuple ('image.repository', 'image.tag'). This is how charts created with
   `helm create` are structured.
 
+- If your chart accepts an image as a 'registry', 'repository' and a 'tag', specify the key
+  as a tuple ('image.registry', 'image.repository', 'image.tag'). This is another common pattern used
+  by many charts.
+
 `flags`: Additional flags to pass to `helm install` (e.g., `['--set', 'key=value']`)
 
 `image_selector`: Image reference to determine containers eligible for Live Update.

--- a/helm_resource/Tiltfile
+++ b/helm_resource/Tiltfile
@@ -41,6 +41,10 @@ def helm_resource(
         as a tuple ('image.repository', 'image.tag'). This is how charts created with
         `helm create` are structured.
 
+      - If your chart accepts an image as a 'registry', 'repository' and a 'tag', specify the key
+        as a tuple ('image.registry', 'image.repository', 'image.tag'). This is another common pattern used
+        by many charts.
+
     flags: Additional flags to pass to `helm install` (e.g., `['--set', 'key=value']`)
     image_selector: Image reference to determine containers eligible for Live Update.
       Only applicable if there are no images in `image_deps`.
@@ -83,8 +87,13 @@ def helm_resource(
     if type(key) == 'string':
       env['TILT_IMAGE_KEY_%s' % i] = key
     elif type(key) == 'tuple':
-      env['TILT_IMAGE_KEY_REPO_%s' % i] = key[0]
-      env['TILT_IMAGE_KEY_TAG_%s' % i] = key[1]
+      if len(key) == 2:
+        env['TILT_IMAGE_KEY_REPO_%s' % i] = key[0]
+        env['TILT_IMAGE_KEY_TAG_%s' % i] = key[1]
+      if len(key) == 3:
+        env['TILT_IMAGE_KEY_REGISTRY_%s' % i] = key[0]
+        env['TILT_IMAGE_KEY_REPO_%s' % i] = key[1]
+        env['TILT_IMAGE_KEY_TAG_%s' % i] = key[2]
     else:
       fail("invalid argument to image_keys at %s: %s" % (i, type(key)))
 

--- a/helm_resource/helm-apply-helper.py
+++ b/helm_resource/helm-apply-helper.py
@@ -18,13 +18,17 @@ for i in range(image_count):
     flags.extend(['--set', '%s=%s' % (key, image)])
     continue
 
+  key0 = os.environ.get('TILT_IMAGE_KEY_REGISTRY_%s' % i, '')
   key1 = os.environ.get('TILT_IMAGE_KEY_REPO_%s' % i, '')
   key2 = os.environ.get('TILT_IMAGE_KEY_TAG_%s' % i, '')
-  parts = image.split(':')
-  repo = ':'.join(parts[:len(parts)-1])
-  tag = ':'.join(parts[len(parts)-1:])
-  flags.extend(['--set', '%s=%s' % (key1, repo),
-                '--set', '%s=%s' % (key2, tag)])
+  registry, image = image.split('/', 1)
+  image, tag = image.split(':', 1)
+  if key0 != '':
+    flags.extend(['--set', '%s=%s' % (key0, registry),
+                  '--set', '%s=%s' % (key1, image)])
+  else:
+    flags.extend(['--set', '%s=%s/%s' % (key1, registry, image)])
+  flags.extend(['--set', '%s=%s' % (key2, tag)])
 install_cmd = ['helm', 'upgrade', '--install']
 install_cmd.extend(flags)
 

--- a/helm_resource/test/Tiltfile
+++ b/helm_resource/test/Tiltfile
@@ -19,9 +19,24 @@ helm_resource(
   labels=['helloworld'],
   flags=['--create-namespace'])
 
+helm_resource(
+  'helloregistry',
+  './helloregistry',
+  namespace='app',
+  deps=['./helloregistry'],
+  image_deps=['helloworld-image'],
+  image_keys=[('image.registry', 'image.repository', 'image.tag')],
+  labels=['helloregistry'],
+  flags=['--create-namespace'])
+
 k8s_resource(
   'helloworld',
   port_forwards=['8080:80'])
+
+k8s_resource(
+  'helloregistry',
+  port_forwards=['8081:80']
+)
 
 helm_repo(
   'bitnami',

--- a/helm_resource/test/helloregistry/.helmignore
+++ b/helm_resource/test/helloregistry/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm_resource/test/helloregistry/Chart.yaml
+++ b/helm_resource/test/helloregistry/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: helloregistry
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/helm_resource/test/helloregistry/templates/NOTES.txt
+++ b/helm_resource/test/helloregistry/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "helloregistry.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "helloregistry.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "helloregistry.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "helloregistry.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm_resource/test/helloregistry/templates/_helpers.tpl
+++ b/helm_resource/test/helloregistry/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "helloregistry.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "helloregistry.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "helloregistry.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "helloregistry.labels" -}}
+helm.sh/chart: {{ include "helloregistry.chart" . }}
+{{ include "helloregistry.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "helloregistry.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "helloregistry.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "helloregistry.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "helloregistry.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm_resource/test/helloregistry/templates/configmaps.yaml
+++ b/helm_resource/test/helloregistry/templates/configmaps.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "helloregistry.fullname" . }}-configmap-default-namespace
+data:
+  hi: world
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "helloregistry.fullname" . }}-configmap-empty-namespace
+  namespace:
+data:
+  hi: world

--- a/helm_resource/test/helloregistry/templates/deployment.yaml
+++ b/helm_resource/test/helloregistry/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "helloregistry.fullname" . }}
+  labels:
+    {{- include "helloregistry.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "helloregistry.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "helloregistry.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "helloregistry.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm_resource/test/helloregistry/templates/hpa.yaml
+++ b/helm_resource/test/helloregistry/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "helloregistry.fullname" . }}
+  labels:
+    {{- include "helloregistry.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "helloregistry.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm_resource/test/helloregistry/templates/ingress.yaml
+++ b/helm_resource/test/helloregistry/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "helloregistry.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "helloregistry.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm_resource/test/helloregistry/templates/service.yaml
+++ b/helm_resource/test/helloregistry/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "helloregistry.fullname" . }}
+  labels:
+    {{- include "helloregistry.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "helloregistry.selectorLabels" . | nindent 4 }}

--- a/helm_resource/test/helloregistry/templates/serviceaccount.yaml
+++ b/helm_resource/test/helloregistry/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "helloregistry.serviceAccountName" . }}
+  labels:
+    {{- include "helloregistry.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm_resource/test/helloregistry/templates/tests/test-connection.yaml
+++ b/helm_resource/test/helloregistry/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "helloregistry.fullname" . }}-test-connection"
+  labels:
+    {{- include "helloregistry.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "helloregistry.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm_resource/test/helloregistry/values.yaml
+++ b/helm_resource/test/helloregistry/values.yaml
@@ -1,0 +1,83 @@
+# Default values for helloworld.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  registry: docker.io
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Currently the `helm_resource` extension supports passing image references to charts either as a single string or as a tuple that maps to two fields in a values file (the default created by `helm create`). This PR adds support for an additional type of structure that uses three fields in a values file:

```yaml
image:
  registry: docker.io
  repository: foo/bar
  tag: 1.0.0
```

A second chart has been added to test this scenario and the test `Tiltfile` has been updated to deploy both simultaneously so as to ensure backwards compatibility with the previous tuple functionality. 