### PR TITLE
k8s_attach: namespace arg works

### DIFF
--- a/k8s_attach/Tiltfile
+++ b/k8s_attach/Tiltfile
@@ -18,7 +18,7 @@ def k8s_attach(name, obj, namespace="", deps=[], live_update=None, image_selecto
 
   args = ["kubectl", "get", "-o=yaml", obj]
   if namespace:
-    args.append("-n", namespace)
+    args.extend(["-n", namespace])
 
   deploy_kwargs={}
   if image_selector:


### PR DESCRIPTION
As list.append https://github.com/bazelbuild/starlark/blob/master/spec.md#list%C2%B7append
seem to only take 1 arg.