### PR TITLE
restart_process: chmod 666 on restart file

### DIFF
--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -45,12 +45,13 @@ def _helper(base_ref, ref, entrypoint, live_update, restart_file=RESTART_FILE, t
     df = '''
     FROM tiltdev/restart-helper:2021-11-03 as restart-helper
 
-    FROM {}
-    RUN ["touch", "{}"]
+    FROM {ref}
+    RUN ["touch", "{file}"]
+    RUN ["chmod", "666", "{file}"]
     COPY --from=restart-helper /tilt-restart-wrapper /
     COPY --from=restart-helper /entr /
-    ENTRYPOINT {}
-    '''.format(base_ref, restart_file, entrypoint_with_entr)
+    ENTRYPOINT {entry}
+    '''.format(ref=base_ref, file=restart_file, entry=entrypoint_with_entr)
 
     # last live_update step should always be to modify $restart_file, which
     # triggers the process wrapper to rerun $entrypoint


### PR DESCRIPTION
Makes the extension friendlier to people running with setups where the runtime
user is not root.
