### PR TITLE
earthly: build extension

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -50,7 +50,7 @@ RUN curl -fsSL https://get.pulumi.com | sh
 ENV PATH=/root/.pulumi/bin:$PATH
 
 # install earthly
-ENV EARTHLY_VERSION=0.6.14
+ARG EARTHLY_VERSION=0.6.14
 RUN wget https://github.com/earthly/earthly/releases/download/v$EARTHLY_VERSION/earthly-linux-amd64 -O /usr/local/bin/earthly \
       chmod +x /usr/local/bin/earthly \
       earthly bootstrap

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -52,8 +52,7 @@ ENV PATH=/root/.pulumi/bin:$PATH
 # install earthly
 ARG EARTHLY_VERSION=0.6.14
 RUN wget https://github.com/earthly/earthly/releases/download/v$EARTHLY_VERSION/earthly-linux-amd64 -O /usr/local/bin/earthly \
-      chmod +x /usr/local/bin/earthly \
-      earthly bootstrap
+      && chmod +x /usr/local/bin/earthly
 
 # ensure any dependencies from manual dpkg installs are ok
 RUN apt update \

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -49,6 +49,12 @@ RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 RUN curl -fsSL https://get.pulumi.com | sh
 ENV PATH=/root/.pulumi/bin:$PATH
 
+# install earthly
+ENV EARTHLY_VERSION=0.6.14
+RUN wget https://github.com/earthly/earthly/releases/download/v$EARTHLY_VERSION/earthly-linux-amd64 -O /usr/local/bin/earthly \
+      chmod +x /usr/local/bin/earthly \
+      earthly bootstrap
+
 # ensure any dependencies from manual dpkg installs are ok
 RUN apt update \
   && apt install -f \

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`docker_build_sub`](/docker_build_sub): Specify extra Dockerfile directives in your Tiltfile beyond [`docker_build`](https://docs.tilt.dev/api.html#api.docker_build).
 - [`docker_build_with_restart`](/restart_process): Wrap a `docker_build` to restart the given entrypoint after a Live Update
 - [`dotenv`](/dotenv): Load environment variables from `.env` or another file.
+- [`earthly`](/earthly): Build container images using [earthly](https://earthly.dev)
 - [`file_sync_only`](/file_sync_only): No-build, no-push, file sync-only development. Useful when you want to live-reload a single config file into an existing public image, like nginx.
 - [`git_resource`](/git_resource): Deploy a dockerfile from a remote repository -- or specify the path to a local checkout for local development.
 - [`hasura`](/hasura): Deploys [Hasura GraphQL Engine](https://hasura.io/) and monitors metadata/migrations changes locally.

--- a/earthly/README.md
+++ b/earthly/README.md
@@ -1,0 +1,36 @@
+# Earthly
+
+Author: [Konrad Malik](https://github.com/konradmalik)
+
+Use [Earthly](https://earthly.dev/) to build images for Tilt.
+
+## Functions
+
+### `earthly_build(target, ref, image_arg, deps, ignore=None, extra_flags=None, extra_args=None, live_update=[])`
+
+- **target**: The name of the earthly target to build.
+  Note that Earthly targets start with '+' but also can refer to targets
+  in another dir or remote locations (see https://docs.earthly.dev/docs/guides/target-ref).
+- **ref**: The name of the image that earthly will build (e.g. ‘myproj/backend’ or ‘myregistry/myproj/backend’).
+  If this image will be used in a k8s resource(s), this ref must match the spec.container.image param for that resource(s).
+- **image_arg**: the name of the earthly ARG that is responsible for setting the resulting image full name (name + tag)
+- **deps**: Changes to the given files or directories that will trigger rebuilds.
+- **ignore**: Changes to the given files or directories do not trigger rebuilds.
+- **extra_flags**: Extra flags to pass to earthy. Expressed as an argv-style array, ex. `['--strict']`.
+- **extra_args**: Extra ARG key-pairs to pass to earthy. Expressed as an argv-style array, ex. `['--PORT=8000']`.
+- **live_update**: Set of steps for updating a running container
+  (see https://docs.tilt.dev/live_update_reference.html)
+
+## Example Usage
+
+```
+load('ext://earthly', 'earthly_build')
+earthly_build(
+    target='+hello',
+    ref='helloimage',
+    image_arg='IMAGE_NAME',
+    deps='.',
+    ignore='./test.sh',
+    extra_flags=['--strict'],
+    extra_args=['--PORT=8000'])
+```

--- a/earthly/README.md
+++ b/earthly/README.md
@@ -15,8 +15,9 @@ Use [Earthly](https://earthly.dev/) to build images for Tilt.
 - **ref**: The name of the image that earthly will build (e.g. ‘myproj/backend’ or ‘myregistry/myproj/backend’).
   If this image will be used in a k8s resource(s), this ref must match the spec.container.image param for that resource(s).
 - **image_arg**: the name of the earthly ARG that is responsible for setting the resulting image full name (name + tag)
-- **deps**: Changes to the given files or directories that will trigger rebuilds. Relative to the Tiltfile. Defaults to `context`.
-- **ignore**: Changes to the given files or directories do not trigger rebuilds.
+- **deps**: Changes to the given files or directories that will trigger rebuilds. Relative to the Tiltfile. Defaults to `context`. Only accepts real paths, not file globs.
+- **ignore**: set of file patterns that will be ignored. Ignored files will not trigger builds. Follows the dockerignore syntax.
+  Patterns/filepaths will be evaluated relative to each dep (e.g. if you specify deps=['dep1', 'dep2'] and ignores=['foobar'] , Tilt will ignore both deps1/foobar and dep2/foobar ).
 - **extra_flags**: Extra flags to pass to earthly. Expressed as an argv-style array, ex. `['--strict']`.
 - **extra_args**: Extra ARG key-pairs to pass to earthly. Expressed as an argv-style array, ex. `['--PORT=8000']`.
 - **live_update**: Set of steps for updating a running container

--- a/earthly/README.md
+++ b/earthly/README.md
@@ -8,16 +8,17 @@ Use [Earthly](https://earthly.dev/) to build images for Tilt.
 
 ### `earthly_build(target, ref, image_arg, deps, ignore=None, extra_flags=None, extra_args=None, live_update=[])`
 
+- **context**: The dir where the earthly command will be executed relative to the Tiltfile.
 - **target**: The name of the earthly target to build.
   Note that Earthly targets start with '+' but also can refer to targets
   in another dir or remote locations (see https://docs.earthly.dev/docs/guides/target-ref).
 - **ref**: The name of the image that earthly will build (e.g. ‘myproj/backend’ or ‘myregistry/myproj/backend’).
   If this image will be used in a k8s resource(s), this ref must match the spec.container.image param for that resource(s).
 - **image_arg**: the name of the earthly ARG that is responsible for setting the resulting image full name (name + tag)
-- **deps**: Changes to the given files or directories that will trigger rebuilds.
+- **deps**: Changes to the given files or directories that will trigger rebuilds. Relative to the Tiltfile. Defaults to `context`.
 - **ignore**: Changes to the given files or directories do not trigger rebuilds.
-- **extra_flags**: Extra flags to pass to earthy. Expressed as an argv-style array, ex. `['--strict']`.
-- **extra_args**: Extra ARG key-pairs to pass to earthy. Expressed as an argv-style array, ex. `['--PORT=8000']`.
+- **extra_flags**: Extra flags to pass to earthly. Expressed as an argv-style array, ex. `['--strict']`.
+- **extra_args**: Extra ARG key-pairs to pass to earthly. Expressed as an argv-style array, ex. `['--PORT=8000']`.
 - **live_update**: Set of steps for updating a running container
   (see https://docs.tilt.dev/live_update_reference.html)
 
@@ -26,10 +27,10 @@ Use [Earthly](https://earthly.dev/) to build images for Tilt.
 ```
 load('ext://earthly', 'earthly_build')
 earthly_build(
+    context='.',
     target='+hello',
     ref='helloimage',
     image_arg='IMAGE_NAME',
-    deps='.',
     ignore='./test.sh',
     extra_flags=['--strict'],
     extra_args=['--PORT=8000'])

--- a/earthly/Tiltfile
+++ b/earthly/Tiltfile
@@ -1,24 +1,25 @@
-# -*- mode: Python -*-
-
+# vim: set syntax=python:
 
 def earthly_build(
-  target, ref, image_arg, deps, ignore=None, extra_flags=None, extra_args=None, live_update=[]
+  context, target, ref, image_arg, deps=None, ignore=None, extra_flags=None, extra_args=None, live_update=[]
 ):
   """Use [Earthly](https://earthly.dev/) to build images for Tilt.
   Args:
+    context: The dir where the earthly command will be executed relative to the Tiltfile.
     target: The name of the earthly target to build.
         Note that Earthly targets start with '+' but also can refer to targets
         in another dir or remote locations (see https://docs.earthly.dev/docs/guides/target-ref).
     ref: The name of the image that earthly will build (e.g. ‘myproj/backend’ or ‘myregistry/myproj/backend’).
         If this image will be used in a k8s resource(s), this ref must match the spec.container.image param for that resource(s).
     image_arg: the name of the earthly ARG that is responsible for setting the resulting image full name (name + tag)
-    deps: Changes to the given files or directories that will trigger rebuilds.
+    deps: Changes to the given files or directories that will trigger rebuilds. Relative to the Tiltfile. Defaults to context.
     ignore: Changes to the given files or directories do not trigger rebuilds.
-    extra_flags: Extra flags to pass to earthy. Expressed as an argv-style array, ex. `['--strict']`.
-    extra_args: Extra ARG key-pairs to pass to earthy. Expressed as an argv-style array, ex. `['--PORT=8000']`.
+    extra_flags: Extra flags to pass to earthly. Expressed as an argv-style array, ex. `['--strict']`.
+    extra_args: Extra ARG key-pairs to pass to earthly. Expressed as an argv-style array, ex. `['--PORT=8000']`.
     live_update: Set of steps for updating a running container
         (see https://docs.tilt.dev/live_update_reference.html)
   """
+  deps = deps or [context]
   extra_flags = extra_flags or []
   extra_flags_str = ' '.join([shlex.quote(f) for f in extra_flags])
   extra_args = extra_args or []
@@ -27,8 +28,8 @@ def earthly_build(
   custom_build(
     ref=ref,
     command=(
-      "earthly --allow-privileged %s %s --%s=$EXPECTED_REF %s"
-    ) % (extra_flags_str, shlex.quote(target), shlex.quote(image_arg), extra_args_str),
+      "cd %s && earthly --allow-privileged %s %s --%s=$EXPECTED_REF %s"
+    ) % (shlex.quote(context), extra_flags_str, shlex.quote(target), shlex.quote(image_arg), extra_args_str),
     ignore=ignore,
     deps=deps,
     live_update=live_update,

--- a/earthly/Tiltfile
+++ b/earthly/Tiltfile
@@ -28,7 +28,7 @@ def earthly_build(
   custom_build(
     ref=ref,
     command=(
-      "cd %s && earthly --allow-privileged %s %s --%s=$EXPECTED_REF %s"
+      "cd %s && earthly %s %s --%s=$EXPECTED_REF %s"
     ) % (shlex.quote(context), extra_flags_str, shlex.quote(target), shlex.quote(image_arg), extra_args_str),
     ignore=ignore,
     deps=deps,

--- a/earthly/Tiltfile
+++ b/earthly/Tiltfile
@@ -1,0 +1,36 @@
+# -*- mode: Python -*-
+
+
+def earthly_build(
+  target, ref, image_arg, deps, ignore=None, extra_flags=None, extra_args=None, live_update=[]
+):
+  """Use [Earthly](https://earthly.dev/) to build images for Tilt.
+  Args:
+    target: The name of the earthly target to build.
+        Note that Earthly targets start with '+' but also can refer to targets
+        in another dir or remote locations (see https://docs.earthly.dev/docs/guides/target-ref).
+    ref: The name of the image that earthly will build (e.g. ‘myproj/backend’ or ‘myregistry/myproj/backend’).
+        If this image will be used in a k8s resource(s), this ref must match the spec.container.image param for that resource(s).
+    image_arg: the name of the earthly ARG that is responsible for setting the resulting image full name (name + tag)
+    deps: Changes to the given files or directories that will trigger rebuilds.
+    ignore: Changes to the given files or directories do not trigger rebuilds.
+    extra_flags: Extra flags to pass to earthy. Expressed as an argv-style array, ex. `['--strict']`.
+    extra_args: Extra ARG key-pairs to pass to earthy. Expressed as an argv-style array, ex. `['--PORT=8000']`.
+    live_update: Set of steps for updating a running container
+        (see https://docs.tilt.dev/live_update_reference.html)
+  """
+  extra_flags = extra_flags or []
+  extra_flags_str = ' '.join([shlex.quote(f) for f in extra_flags])
+  extra_args = extra_args or []
+  extra_args_str = ' '.join([shlex.quote(f) for f in extra_args])
+
+  custom_build(
+    ref=ref,
+    command=(
+      "earthly --allow-privileged %s %s --%s=$EXPECTED_REF %s"
+    ) % (extra_flags_str, shlex.quote(target), shlex.quote(image_arg), extra_args_str),
+    ignore=ignore,
+    deps=deps,
+    live_update=live_update,
+    skips_local_docker=False,
+  )

--- a/earthly/Tiltfile
+++ b/earthly/Tiltfile
@@ -12,8 +12,9 @@ def earthly_build(
     ref: The name of the image that earthly will build (e.g. ‘myproj/backend’ or ‘myregistry/myproj/backend’).
         If this image will be used in a k8s resource(s), this ref must match the spec.container.image param for that resource(s).
     image_arg: the name of the earthly ARG that is responsible for setting the resulting image full name (name + tag)
-    deps: Changes to the given files or directories that will trigger rebuilds. Relative to the Tiltfile. Defaults to context.
-    ignore: Changes to the given files or directories do not trigger rebuilds.
+    deps: Changes to the given files or directories that will trigger rebuilds. Relative to the Tiltfile. Defaults to `context`. Only accepts real paths, not file globs.
+    ignore: set of file patterns that will be ignored. Ignored files will not trigger builds. Follows the dockerignore syntax.
+        Patterns/filepaths will be evaluated relative to each dep (e.g. if you specify deps=['dep1', 'dep2'] and ignores=['foobar'] , Tilt will ignore both deps1/foobar and dep2/foobar ).
     extra_flags: Extra flags to pass to earthly. Expressed as an argv-style array, ex. `['--strict']`.
     extra_args: Extra ARG key-pairs to pass to earthly. Expressed as an argv-style array, ex. `['--PORT=8000']`.
     live_update: Set of steps for updating a running container

--- a/earthly/test/Earthfile
+++ b/earthly/test/Earthfile
@@ -1,0 +1,13 @@
+VERSION 0.6
+
+hello:
+    FROM busybox
+    WORKDIR /app
+    COPY main.sh .
+    COPY index.html .
+    ENTRYPOINT ./main.sh
+
+    ARG --required IMAGE_NAME
+    ARG PORT
+    ENV PORT=$PORT
+    SAVE IMAGE --push $IMAGE_NAME

--- a/earthly/test/Tiltfile
+++ b/earthly/test/Tiltfile
@@ -1,12 +1,12 @@
-# -*- mode: Python -*-
+# vim: set syntax=python:
 
 load('../Tiltfile', 'earthly_build')
 
 earthly_build(
+    context='.',
     target='+hello',
     ref='helloimage',
     image_arg='IMAGE_NAME',
-    deps='.',
     ignore='./test.sh',
     extra_flags=['--strict'],
     extra_args=['--PORT=8000'])

--- a/earthly/test/Tiltfile
+++ b/earthly/test/Tiltfile
@@ -1,0 +1,21 @@
+# -*- mode: Python -*-
+
+load('../Tiltfile', 'earthly_build')
+
+earthly_build(
+    target='+hello',
+    ref='helloimage',
+    image_arg='IMAGE_NAME',
+    deps='.',
+    ignore='./test.sh',
+    extra_flags=['--strict'],
+    extra_args=['--PORT=8000'])
+
+k8s_yaml('deployment.yaml')
+
+k8s_resource(
+    'example-earthly',
+    port_forwards='8000',
+    labels=['web']
+)
+

--- a/earthly/test/deployment.yaml
+++ b/earthly/test/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-earthly
+  labels:
+    app: example-earthly
+spec:
+  selector:
+    matchLabels:
+      app: example-earthly
+  template:
+    metadata:
+      labels:
+        app: example-earthly
+    spec:
+      containers:
+      - name: example-earthly
+        image: helloimage
+        ports:
+        - containerPort: 8000

--- a/earthly/test/index.html
+++ b/earthly/test/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body style="font-size: 30px; font-family: sans-serif; margin: 0;">
+    <div style="display: flex; flex-direction: column; width: 100vw; height: 100vh; align-items: center; justify-content: center;">
+      <div>Hello from Earthly!</div>
+    </div>
+  </body>
+</html>

--- a/earthly/test/main.sh
+++ b/earthly/test/main.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+port="${PORT:-8080}"
+echo "Serving files on port $port"
+busybox httpd -f -p "$port"

--- a/earthly/test/test.sh
+++ b/earthly/test/test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -ex
+
+cd "$(dirname "$0")"
+
+tilt ci
+tilt down


### PR DESCRIPTION
Hey all,
I've created an extension that allows to use [Earthly](https://docs.earthly.dev/) as a tool to build images for Tilt.

The code is largely based on the `podman` extension.

Let me know if something needs changing.