### PR TITLE
Pack - allow `BP_LIVE_RELOAD_ENABLED` to be set by the user

### DIFF
--- a/pack/Tiltfile
+++ b/pack/Tiltfile
@@ -25,7 +25,7 @@ def pack(
     name = name.split(":")[0]
 
     envs = list(env_vars)
-    if 'BP_LIVE_RELOAD_ENABLED=true' not in envs:
+    if not bool([e for e in envs if ('BP_LIVE_RELOAD_ENABLED' in e)]):
         envs.append('BP_LIVE_RELOAD_ENABLED=true')
 
     deps_copy = list(deps)


### PR DESCRIPTION
## Problem

Currently the pack extension always sets `BP_LIVE_RELOAD_ENABLED` to `true`.

There are some common [Buildpacks builders](https://github.com/paketo-buildpacks/tiny-builder) which are not compatible with `watchexec`, which is [expected by this flag](https://paketo.io/docs/howto/python/#enable-process-reloading).

This extension will error if trying to build with one of these buildpacks e.g. 

## Fix

This PR allows the user to provide the `BP_LIVE_RELOAD_ENABLED` flag.  If the flag is provided by the user, e.g. `BP_LIVE_RELOAD_ENABLED=false`, the extension will no longer try to overwrite or append a duplicate, conflicting flag.