### PR TITLE
feat(ecu): allow helm_remote to have labels parameters

### DIFF
--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -54,7 +54,7 @@ metadata:
 #   =====================================
 
 
-def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], set=[], namespace='', version='', username='', password='', allow_duplicates=False, create_namespace=False):
+def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], set=[], namespace='', version='', username='', password='', allow_duplicates=False, create_namespace=False, labels=[]):
     # ======== Helper methods
     def get_local_repo(repo_name, repo_url):
         # if no repos are present, helm exit code is >0 and stderr output buffered
@@ -181,6 +181,9 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
         k8s_yaml(yaml, allow_duplicates=allow_duplicates)
     else:
         k8s_yaml(yaml)
+
+    if len(labels) > 0:
+        k8s_resource(workload=release_name,  labels=labels)
 
     return yaml
 


### PR DESCRIPTION
Hello,

I would like to improve the helm_remote function to be able to add labels directly. I do not know if it is the good way to do it but it works well.
However, for complex chart, using the `release_name` for the workload is not enought.

For exemple, the prometheus-stack helm chart
```
helm_remote(
  'kube-prometheus-stack',
  repo_url='https://prometheus-community.github.io/helm-charts',
  release_name='prometheus-stack',
  namespace="monitoring",
)
```

This chart is alone but it will declare four resources so my change is not enought. What do you think?

![image](https://user-images.githubusercontent.com/9136206/172486207-5bb52008-14e8-4bbd-ac4c-59f635c6edd3.png)

