### PR TITLE
circleci: move images to docker org

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiltdev/tilt:latest
+FROM docker/tilt:latest
 
 # Utils for our CI
 RUN apt update \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   validate:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-extensions-ci@sha256:13da9ee95199c128f18d0a472a73ed4808f673f6cb92d3b01932e9fa083a6a31
+      - image: docker/tilt-extensions-ci@sha256:ce6b74afb479e6ed5fe4b7aa499e68766fc2d069ff28309363b4e9e6a64509d8
 
     steps:
       - checkout
@@ -11,7 +11,7 @@ jobs:
 
   shellcheck:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-extensions-ci@sha256:13da9ee95199c128f18d0a472a73ed4808f673f6cb92d3b01932e9fa083a6a31
+      - image: docker/tilt-extensions-ci@sha256:ce6b74afb479e6ed5fe4b7aa499e68766fc2d069ff28309363b4e9e6a64509d8
 
     steps:
       - checkout
@@ -22,7 +22,7 @@ jobs:
     # spaces in paths, which is common on macOS (/Application Support/)
     working_directory: ~/tilt extensions
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-extensions-ci@sha256:13da9ee95199c128f18d0a472a73ed4808f673f6cb92d3b01932e9fa083a6a31
+      - image: docker/tilt-extensions-ci@sha256:ce6b74afb479e6ed5fe4b7aa499e68766fc2d069ff28309363b4e9e6a64509d8
 
     steps:
       - setup_remote_docker:

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ test:
 	./test.sh
 
 publish-ci-image:
-	docker build --pull --platform linux/amd64 -t gcr.io/windmill-public-containers/tilt-extensions-ci -f .circleci/Dockerfile .circleci
-	docker push gcr.io/windmill-public-containers/tilt-extensions-ci
+	docker build --pull --platform linux/amd64 -t docker/tilt-extensions-ci -f .circleci/Dockerfile .circleci
+	docker push docker/tilt-extensions-ci
 
 shellcheck:
 	find . -type f -name '*.sh' -not -path "*/node_modules/*" -not -path "*/.git-sources/*" -not -path "*/.git/*" -exec \


### PR DESCRIPTION
Hello @nicksieger,

Please review the following commits I made in branch nicks/images:

45e3330d1e1653e4b6495183313db7fa017f9c4b (2022-06-10 15:01:39 -0400)
circleci: move images to docker org
Signed-off-by: Nick Santos <nick.santos@docker.com>

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics