### PR TITLE
Add secret type to secret_from_dict()

### DIFF
--- a/secret/README.md
+++ b/secret/README.md
@@ -41,6 +41,22 @@ Returns YAML for a secret from a dictionary.
 * `inputs` ( dict) - A dict of keys and values to use. Nesting is not supported
 
 
+### secret_yaml_registry
+
+```
+secret_yaml_registry(name: str, namespace: str = "", flags_dict: dict = None)
+```
+
+Returns YAML for a `docker-registry` type secret. Equivelent to: 
+
+```
+kubectl create secret docker-registry artifact-registry \
+ --docker-server=host.somedomain \
+ --docker-username=_json_key \
+ --docker-password="$(cat service-account.json)" \
+ --docker-email=email@email.com
+```
+
 ### secret_yaml_tls
 
 ```
@@ -84,6 +100,16 @@ secret_create_generic('gcp-key', from_file='key.json=./gcp-creds.json')
 load('ext://secret', 'secret_from_dict')
 k8s_yaml(secret_from_dict("secrets", inputs = {
     'SOME_TOKEN' : os.getenv('SOME_TOKEN')
+}))
+```
+
+### For a docker-registry secret
+```
+k8s_yaml(registry_secret("artifact-registry", flags_dict = {
+    'docker-server': 'registry_hostname',
+    'docker-username': '_json_key',
+    'docker-email': 'test@test.com,
+    'docker-password': read_file(service-account.json')
 }))
 ```
 

--- a/secret/Tiltfile
+++ b/secret/Tiltfile
@@ -59,12 +59,14 @@ def secret_yaml_generic(name, namespace="", from_file=None, secret_type=None, fr
   args.extend(["-o=yaml", "--dry-run=client"])
   return local(args, quiet=True, echo_off=True)
 
-def secret_from_dict(name, namespace="", inputs={}):
+def secret_from_dict(name, namespace="", inputs={}, secret_type=None):
     """Returns YAML for a generic secret
     Args:
         name: The configmap name.
         namespace: The namespace.
         inputs: A dict of keys and values to use. Nesting is not supported
+        secret_type (optional): Specify the type of the secret
+          Example: 'kubernetes.io/dockerconfigjson'
     Returns:
         The secret YAML as a blob
     """
@@ -86,6 +88,12 @@ def secret_from_dict(name, namespace="", inputs={}):
     for k,v in inputs.items():
         args.extend(["--from-literal", "%s=%s" % (k,v)])
 
+    if secret_type:
+      if type(secret_type) == "string":
+        args.extend(["--type", secret_type])
+      else:
+        fail("Bad secret_type argument: %s" % secret_type)
+        
     args.extend(["-o=yaml", "--dry-run=client"])
     return local(args, quiet=True, echo_off=True)
 

--- a/secret/Tiltfile
+++ b/secret/Tiltfile
@@ -59,14 +59,12 @@ def secret_yaml_generic(name, namespace="", from_file=None, secret_type=None, fr
   args.extend(["-o=yaml", "--dry-run=client"])
   return local(args, quiet=True, echo_off=True)
 
-def secret_from_dict(name, namespace="", inputs={}, secret_type=None):
+def secret_from_dict(name, namespace="", inputs={}):
     """Returns YAML for a generic secret
     Args:
         name: The configmap name.
         namespace: The namespace.
         inputs: A dict of keys and values to use. Nesting is not supported
-        secret_type (optional): Specify the type of the secret
-          Example: 'kubernetes.io/dockerconfigjson'
     Returns:
         The secret YAML as a blob
     """
@@ -88,12 +86,6 @@ def secret_from_dict(name, namespace="", inputs={}, secret_type=None):
     for k,v in inputs.items():
         args.extend(["--from-literal", "%s=%s" % (k,v)])
 
-    if secret_type:
-      if type(secret_type) == "string":
-        args.extend(["--type", secret_type])
-      else:
-        fail("Bad secret_type argument: %s" % secret_type)
-        
     args.extend(["-o=yaml", "--dry-run=client"])
     return local(args, quiet=True, echo_off=True)
 

--- a/secret/Tiltfile
+++ b/secret/Tiltfile
@@ -89,6 +89,38 @@ def secret_from_dict(name, namespace="", inputs={}):
     args.extend(["-o=yaml", "--dry-run=client"])
     return local(args, quiet=True, echo_off=True)
 
+def registry_secret(name, namespace="", flags_dict={}):
+    """Returns YAML for a docker-registry secret
+    Args:
+        name: The configmap name.
+        namespace: The namespace.
+        inputs: A dict of keys and values to use. Nesting is not supported
+        flags_dict (optional): the flags used by docker-registry secret command
+          Example: '{"docker_server": "host", "docker_username": "username", "docker-password": "password", "docker_email": "email@email.com"}'
+    Returns:
+        The secret YAML as a blob
+    """
+
+    args = [
+        "kubectl",
+        "create",
+        "secret",
+        "docker-registry",
+        name,
+    ]
+
+    if namespace:
+        args.extend(["-n", namespace])
+
+    if type(flags_dict) != "dict":
+        fail("Bad argument to secret_from_dict, inputs was not dict typed")
+
+    for k,v in flags_dict.items():
+        args.extend(["--%s=%s" % (k,v)])
+
+    args.extend(["-o=yaml", "--dry-run=client"])
+    return local(args, quiet=True, echo_off=True)
+
 def secret_create_generic(name, namespace="", from_file=None, secret_type=None, from_env_file=None):
   """Creates a secret in the current Kubernetes cluster.
 

--- a/secret/Tiltfile
+++ b/secret/Tiltfile
@@ -89,14 +89,13 @@ def secret_from_dict(name, namespace="", inputs={}):
     args.extend(["-o=yaml", "--dry-run=client"])
     return local(args, quiet=True, echo_off=True)
 
-def registry_secret(name, namespace="", flags_dict={}):
+def secret_yaml_registry(name, namespace="", flags_dict={}):
     """Returns YAML for a docker-registry secret
     Args:
         name: The configmap name.
         namespace: The namespace.
-        inputs: A dict of keys and values to use. Nesting is not supported
         flags_dict (optional): the flags used by docker-registry secret command
-          Example: '{"docker_server": "host", "docker_username": "username", "docker-password": "password", "docker_email": "email@email.com"}'
+          Example: '{"docker-server": "host", "docker-username": "username", "docker-password": "password", "docker-email": "email@email.com"}'
     Returns:
         The secret YAML as a blob
     """


### PR DESCRIPTION
In order to perform an operation like this kubectl command:

```
kubectl create secret docker-registry artifact-registry \
 --docker-server=host.somedomain \
 --docker-username=_json_key \
 --docker-password="$(cat service-account.json)" \
 --docker-email=email@email.com
```

This does not work with `secret_yaml_generic()` or `secret_from_dict()`

I have created a new function for this, that will hopefully make creating these secrets easier for others: `registry_secret()`
```
name: The configmap name.
namespace: The namespace.
inputs: A dict of keys and values to use. Nesting is not supported
flags_dict (optional): the flags used by docker-registry secret command
  Example: '{"docker_server": "host", "docker_username": "username", "docker-password": "password", "docker_email": "email@email.com"}'
          ```
          
Usage example: 

k8s_yaml(registry_secret("artifact-registry", flags_dict = {
    'docker-server': 'registry_hostname',
    'docker-username': '_json_key',
    'docker-email': 'test@test.com,
    'docker-password': read_file(service-account.json')
}))