### PR TITLE
helm_resource: fix helm_resource() so it will deploy to custom namespaces

### DIFF
--- a/helm_resource/helm-apply-helper.py
+++ b/helm_resource/helm-apply-helper.py
@@ -57,6 +57,7 @@ namespace = os.environ.get('NAMESPACE', '')
 if namespace:
   install_cmd.extend(['--namespace', namespace])
   get_cmd.extend(['--namespace', namespace])
+  kubectl_cmd.extend(['--namespace', namespace])
 
 install_cmd.extend([release_name, chart])
 get_cmd.extend([release_name])


### PR DESCRIPTION
Make `helm_resource()` pass its namespace parameter to the `kubectl` command, not just the `helm` command.

This fixes a bug where deploying a new service into a custom namespace would fail on the `kubectl get -oyaml -` step.  `helm_resource()` calls to Helm use `helm --namespace SOME_NAME` to work on a specific namespace. `helm_resource()` calls to `kubectl` would look in the default namespace for the resources that Helm just created in the custom namespace, causing `kubectl` to return an error code.