### PR TITLE
earthly: add windows-specific command and restarts

### DIFF
--- a/earthly/README.md
+++ b/earthly/README.md
@@ -23,9 +23,30 @@ Use [Earthly](https://earthly.dev/) to build images for Tilt.
 - **live_update**: Set of steps for updating a running container
   (see https://docs.tilt.dev/live_update_reference.html)
 
+### `earthly_build_with_restart(context, target, ref, image_arg, entrypoint, deps=None, ignore=None, extra_flags=None, extra_args=None, live_update=[], base_suffix='-tilt_docker_build_with_restart_base', restart_file=RESTART_FILE, trigger=None, exit_policy='restart')`
+
+- **context**: The dir where the earthly command will be executed relative to the Tiltfile.
+- **target**: The name of the earthly target to build.
+  Note that Earthly targets start with '+' but also can refer to targets
+  in another dir or remote locations (see https://docs.earthly.dev/docs/guides/target-ref).
+- **ref**: The name of the image that earthly will build (e.g. ‘myproj/backend’ or ‘myregistry/myproj/backend’).
+  If this image will be used in a k8s resource(s), this ref must match the spec.container.image param for that resource(s).
+- **image_arg**: the name of the earthly ARG that is responsible for setting the resulting image full name (name + tag)
+- **entrypoint**: the command to be (re-)executed when the container starts or when a live_update is run
+- **deps**: Changes to the given files or directories that will trigger rebuilds. Relative to the Tiltfile. Defaults to `context`. Only accepts real paths, not file globs.
+- **ignore**: set of file patterns that will be ignored. Ignored files will not trigger builds. Follows the dockerignore syntax.
+  Patterns/filepaths will be evaluated relative to each dep (e.g. if you specify deps=['dep1', 'dep2'] and ignores=['foobar'] , Tilt will ignore both deps1/foobar and dep2/foobar ).
+- **extra_flags**: Extra flags to pass to earthly. Expressed as an argv-style array, ex. `['--strict']`.
+- **extra_args**: Extra ARG key-pairs to pass to earthly. Expressed as an argv-style array, ex. `['--PORT=8000']`.
+- **live_update**: Set of steps for updating a running container
+  (see https://docs.tilt.dev/live_update_reference.html)
+- **base_suffix**: suffix for naming the base image, applied as {ref}{base_suffix}
+- **restart_file**: file that Tilt will update during a live_update to signal the entrypoint to rerun
+- **trigger**: (optional) list of local paths. If specified, the process will ONLY be restarted when there are changes
+
 ## Example Usage
 
-```
+```python
 load('ext://earthly', 'earthly_build')
 earthly_build(
     context='.',
@@ -35,4 +56,16 @@ earthly_build(
     ignore='./test.sh',
     extra_flags=['--strict'],
     extra_args=['--PORT=8000'])
+
+load('ext://earthly', 'earthly_build_with_restart')
+earthly_build_with_restart(
+    entrypoint='./main.sh',
+    context='.',
+    target='+hello',
+    ref='helloimage',
+    image_arg='IMAGE_NAME',
+    ignore='./test.sh',
+    extra_flags=['--strict'],
+    extra_args=['--PORT=8000'],
+    live_update=[run("echo 'updating!'")])
 ```

--- a/earthly/Tiltfile
+++ b/earthly/Tiltfile
@@ -1,4 +1,7 @@
 # vim: set syntax=python:
+RESTART_FILE = '/tmp/.restart-proc'
+
+load('ext://restart_process', 'custom_build_with_restart')
 
 def earthly_build(
   context, target, ref, image_arg, deps=None, ignore=None, extra_flags=None, extra_args=None, live_update=[]
@@ -38,4 +41,53 @@ def earthly_build(
     deps=deps,
     live_update=live_update,
     skips_local_docker=False,
+  )
+
+def earthly_build_with_restart(
+  context, target, ref, image_arg, entrypoint, deps=None, ignore=None, extra_flags=None, extra_args=None, live_update=[],
+  base_suffix='-tilt_docker_build_with_restart_base', restart_file=RESTART_FILE, trigger=None, exit_policy='restart'):
+  """Use [Earthly](https://earthly.dev/) to build images for Tilt.
+  Args:
+    context: The dir where the earthly command will be executed relative to the Tiltfile.
+    target: The name of the earthly target to build.
+        Note that Earthly targets start with '+' but also can refer to targets
+        in another dir or remote locations (see https://docs.earthly.dev/docs/guides/target-ref).
+    ref: The name of the image that earthly will build (e.g. ‘myproj/backend’ or ‘myregistry/myproj/backend’).
+        If this image will be used in a k8s resource(s), this ref must match the spec.container.image param for that resource(s).
+    image_arg: the name of the earthly ARG that is responsible for setting the resulting image full name (name + tag)
+    entrypoint: the command to be (re-)executed when the container starts or when a live_update is run
+    deps: Changes to the given files or directories that will trigger rebuilds. Relative to the Tiltfile. Defaults to `context`. Only accepts real paths, not file globs.
+    ignore: set of file patterns that will be ignored. Ignored files will not trigger builds. Follows the dockerignore syntax.
+        Patterns/filepaths will be evaluated relative to each dep (e.g. if you specify deps=['dep1', 'dep2'] and ignores=['foobar'] , Tilt will ignore both deps1/foobar and dep2/foobar ).
+    extra_flags: Extra flags to pass to earthly. Expressed as an argv-style array, ex. `['--strict']`.
+    extra_args: Extra ARG key-pairs to pass to earthly. Expressed as an argv-style array, ex. `['--PORT=8000']`.
+    live_update: Set of steps for updating a running container
+        (see https://docs.tilt.dev/live_update_reference.html)
+    base_suffix: suffix for naming the base image, applied as {ref}{base_suffix}
+    restart_file: file that Tilt will update during a live_update to signal the entrypoint to rerun
+    trigger: (optional) list of local paths. If specified, the process will ONLY be restarted when there are changes
+            to the given file(s); as the parameter of the same name in the LiveUpdate `run` step.
+  """
+  deps = deps or [context]
+  extra_flags = extra_flags or []
+  extra_flags_str = ' '.join([shlex.quote(f) for f in extra_flags])
+  extra_args = extra_args or []
+  extra_args_str = ' '.join([shlex.quote(f) for f in extra_args])
+
+  custom_build_with_restart(
+    ref=ref,
+    command=(
+      "cd %s && earthly %s %s --%s=$EXPECTED_REF %s"
+    ) % (shlex.quote(context), extra_flags_str, shlex.quote(target), shlex.quote(image_arg), extra_args_str),
+    command_bat=(
+      "cd %s && earthly %s %s --%s=%%EXPECTED_REF%% %s"
+    ) % (shlex.quote(context), extra_flags_str, shlex.quote(target), shlex.quote(image_arg), extra_args_str),
+    ignore=ignore,
+    deps=deps,
+    live_update=live_update,
+    entrypoint=entrypoint,
+    base_suffix=base_suffix,
+    restart_file=restart_file,
+    trigger=trigger,
+    exit_policy=exit_policy,
   )

--- a/earthly/Tiltfile
+++ b/earthly/Tiltfile
@@ -31,6 +31,9 @@ def earthly_build(
     command=(
       "cd %s && earthly %s %s --%s=$EXPECTED_REF %s"
     ) % (shlex.quote(context), extra_flags_str, shlex.quote(target), shlex.quote(image_arg), extra_args_str),
+    command_bat=(
+      "cd %s && earthly %s %s --%s=%%EXPECTED_REF%% %s"
+    ) % (shlex.quote(context), extra_flags_str, shlex.quote(target), shlex.quote(image_arg), extra_args_str),
     ignore=ignore,
     deps=deps,
     live_update=live_update,

--- a/earthly/test/Tiltfile.restart
+++ b/earthly/test/Tiltfile.restart
@@ -1,0 +1,23 @@
+# vim: set syntax=python:
+
+load('../Tiltfile', 'earthly_build_with_restart')
+
+earthly_build_with_restart(
+    entrypoint='./main.sh',
+    context='.',
+    target='+hello',
+    ref='helloimage',
+    image_arg='IMAGE_NAME',
+    ignore='./test.sh',
+    extra_flags=['--strict'],
+    extra_args=['--PORT=8000'],
+    live_update=[run("echo 'updating!'")])
+
+k8s_yaml('deployment.yaml')
+
+k8s_resource(
+    'example-earthly',
+    port_forwards='8000',
+    labels=['web']
+)
+

--- a/earthly/test/test.sh
+++ b/earthly/test/test.sh
@@ -4,5 +4,8 @@ set -ex
 
 cd "$(dirname "$0")"
 
-tilt ci
-tilt down
+tilt ci -f ./Tiltfile
+tilt down -f ./Tiltfile
+
+tilt ci -f ./Tiltfile.restart
+tilt down -f ./Tiltfile.restart


### PR DESCRIPTION
Turns out that for windows-native earthly installations the `$EXPECTED_REF` variable was not expanded properly.
Needed to add a windows-specific command via `command_bat`.

Additionally, I added a "docker_build_with_restart"-like functionality.