### PR TITLE
test: remove the helm_remote/gloo tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 */test/.tilt-cache
 */test/.build
 */test/tilt_modules
+*/__pycache__
 
 workflow_*.tmp

--- a/helm_remote/test/Tiltfile
+++ b/helm_remote/test/Tiltfile
@@ -6,12 +6,6 @@ helm_remote('memcached', repo_url='https://charts.bitnami.com/bitnami')
 if not os.path.exists('./.helm/memcached'):
   fail('memcached failed to load in the right directory')
 
-# This chart has a bunch of CRDs (including templated CRDs), so we can test the CRD init logic.
-helm_remote('gloo', repo_url='https://storage.googleapis.com/solo-public-helm',
-            # The gloo chart has duplicate resources, see discussion here:
-            # https://github.com/tilt-dev/tilt/issues/3656
-            allow_duplicates=True)
-
 docker_build('helm-remote-test-verify', '.')
 k8s_yaml('job.yaml')
 k8s_resource('helm-remote-test-verify', resource_deps=['memcached'])


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/helm_remote:

6afe913a6c2b3b9c91b2c3f518c30eef01358c90 (2022-07-08 18:40:15 -0400)
test: remove the helm_remote/gloo tests
the chart is failing to install. i think this is a problem
with the underlying chart, now with anything tilt is doing.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics