### PR TITLE
Expose disabled and requires_confirmation for uibutton extension

### DIFF
--- a/uibutton/README.md
+++ b/uibutton/README.md
@@ -55,21 +55,25 @@ cmd_button(
     icon_name=None,
     icon_svg=None,
     inputs=[],
+    disabled=False,
+    requires_confirmation=False,
 )
 ```
 
 Creates a button for a resource that runs the given command when clicked.
 
-| Argument    | Type                                         | Description                                                                                                                               |
-|-------------|----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`      | `str`                                        | Unique ID for button                                                                                                                      |
-| `resource`  | `str`                                        | Resource to associate button with (required if `location=location.RESOURCE`)                                                              |
-| `argv`      | `List[str]`                                  | Local command to run when button is clicked                                                                                               |
-| `text`      | `str`                                        | Text to display on button (optional: defaults to `name`)                                                                                  |
-| `location`  | `str` (enum)                                 | Button placement in UI (see `location` section below)                                                                                     |
-| `icon_name` | `str`                                        | Name of [Material Icons font ligature][material-icons-font] to use as icon (at most one of `icon_name` or `icon_svg` should be specified) |
-| `icon_svg`  | `str` or `Blob`                              | `<svg>` to use as icon; should have 24x24px viewport (at most one of `icon_name` or `icon_svg` should be specified)                       |
-| `inputs`    | `List[typing.Union[text_input, bool_input]]` | Form inputs for butdown (optional)                                                                                                        |
+| Argument                | Type                                         | Description                                                                                                                               |
+|-------------------------|----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                  | `str`                                        | Unique ID for button                                                                                                                      |
+| `resource`              | `str`                                        | Resource to associate button with (required if `location=location.RESOURCE`)                                                              |
+| `argv`                  | `List[str]`                                  | Local command to run when button is clicked                                                                                               |
+| `text`                  | `str`                                        | Text to display on button (optional: defaults to `name`)                                                                                  |
+| `location`              | `str` (enum)                                 | Button placement in UI (see `location` section below)                                                                                     |
+| `icon_name`             | `str`                                        | Name of [Material Icons font ligature][material-icons-font] to use as icon (at most one of `icon_name` or `icon_svg` should be specified) |
+| `icon_svg`              | `str` or `Blob`                              | `<svg>` to use as icon; should have 24x24px viewport (at most one of `icon_name` or `icon_svg` should be specified)                       |
+| `inputs`                | `List[typing.Union[text_input, bool_input]]` | Form inputs for butdown (optional)                                                                                                        |
+| `disabled`              | `bool`                                       | Whether the button is disabled (optional, default to `False`)                                                                             |
+| `requires_confirmation` | `bool`                                       | Whether the button requires a second click to activate (optional, default to `False`)                                                     |
 
 ### `location`
 To specify button location, you can bind the `location` helper type or pass a string, e.g. `location=location.NAV` and `location='nav'` are equivalent.

--- a/uibutton/Tiltfile
+++ b/uibutton/Tiltfile
@@ -8,7 +8,7 @@ location = struct(
 
 valid_subcommands = ['up', 'ci']
 
-def _button(name, location, text='', icon=None, annotations={}, inputs=[]):
+def _button(name, location, text='', icon=None, annotations={}, inputs=[], disabled=False, requires_confirmation=False):
     text = text or name
     btn = {
         "apiVersion": "tilt.dev/v1alpha1",
@@ -19,6 +19,8 @@ def _button(name, location, text='', icon=None, annotations={}, inputs=[]):
         },
         "spec": {
             "text": text,
+            "disabled": disabled,
+            "requiresConfirmation": requires_confirmation,
             "location": {
                 "componentType": location.type,
                 "componentID": location.id,
@@ -61,7 +63,7 @@ def _start_after():
 
 def cmd_button(name, resource='', argv=[], text=None,
                location=LOCATION_RESOURCE, icon_name=None, icon_svg=None,
-               inputs=[]):
+               inputs=[], disabled=False, requires_confirmation=False):
     if config.tilt_subcommand not in valid_subcommands:
         return
 
@@ -99,6 +101,8 @@ def cmd_button(name, resource='', argv=[], text=None,
         icon=struct(name=icon_name, svg=icon_svg),
         annotations=btn_annotations,
         inputs=inputs,
+        disabled=disabled,
+        requires_confirmation=requires_confirmation,
     )
     cmd = {
         "apiVersion": "tilt.dev/v1alpha1",

--- a/uibutton/test/Tiltfile
+++ b/uibutton/test/Tiltfile
@@ -17,3 +17,8 @@ cmd_button('nav-button-std', argv=["echo", "Hello from nav"],
 cmd_button('nav-button-hello', argv=["sh", "-c", "echo Hello, $NAME"],
            location=location.NAV, icon_name='front_hand', text='Hello',
            inputs=[text_input('NAME')])
+cmd_button('nav-button-disabled', argv=["echo", "Hello from nav"],
+           location=location.NAV, icon_name='calendar_today', disabled=True)
+cmd_button('nav-button-confirm', argv=["echo", "Hello from nav"],
+           location=location.NAV, icon_name='calendar_today', requires_confirmation=True)
+


### PR DESCRIPTION
Hi all,

We've encountered use cases for having disabled buttons, as well as buttons that require confirmation (e.g. destructive actions), and we noticed that those features are supported by Tilt. However, the uibutton extension doesn't expose those params. We tested those changes in our Tiltfile and felt like it would be a quick win to share this to the main repo.

Let me know what you think!