### PR TITLE
Add support for kubectl_build `--push` argument

### DIFF
--- a/kubectl_build/README.md
+++ b/kubectl_build/README.md
@@ -35,6 +35,16 @@ kubectl_build('gcr.io/foo/bar', '.', registry_secret='my-secret')
 
 You may also set the `KUBECTL_BUILD_REGISTRY_SECRET` environment variable with the secret name.
 
+## Pushing image to a registry
+
+`kubectl_build` can push the image to a registry by supplying the `push=True` argument.
+
+Similar to pulling an image from a private repository, you can specify the `registry_secret` argument to authenticate.
+
+```python
+kubectl_build('gcr.io/foo/bar', '.', push=True, registry_secret='my-secret')
+```
+
 ## Limitations
 
 `kubectl_build` supports almost all the [`docker_build`][docker_build] arguments, except:

--- a/kubectl_build/Tiltfile
+++ b/kubectl_build/Tiltfile
@@ -5,7 +5,7 @@ def kubectl_build(ref, context, build_args={}, dockerfile=None,
                   match_in_env_vars=False, ignore=[],
                   entrypoint=[], target=None, ssh=None, secret=None,
                   extra_tag=None, cache_from=[], pull=False,
-                  registry_secret=None):
+                  registry_secret=None, push=False):
     # incompatible parameters with docker_build:
     # only
     # container_args
@@ -74,6 +74,8 @@ def kubectl_build(ref, context, build_args={}, dockerfile=None,
                 command += ['-t', t]
     if pull:
         command += ['--pull']
+    if push:
+        command += ['--push']
     for c in cache_from:
         command += ['--cache-from', c]
     if ssh:


### PR DESCRIPTION
# What is changed

Adding `push` as an optional parameter to `kubectl_build` that appends the `--push` argument to the `kubectl build` command line. This defaults to `False`, maintaining the existing behavior.

# Why

When using an external registry with Tilt, the images built by `kubectl_build` must be pushed to the registry in order to be pulled and started by tilt. This is handled by the `kubectl build` command, but needs to be exposed to the corresponding tilt function.