### PR TITLE
double quotes in extracted local registry -> Error from server (BadRequest): Invalid JSON Patch

### DIFF
--- a/knative/Tiltfile
+++ b/knative/Tiltfile
@@ -38,7 +38,7 @@ kubectl wait --for=condition=Established crd -l=knative.dev/crd-install=true 1>&
   # TODO(nick): Once the registry is in the Tilt API,
   # we should read that here and use it to set knative configuration.
   patch_registry_cmd="""
-REGISTRY=$(kubectl get configmap -n kube-public local-registry-hosting -o=jsonpath='{.data.localRegistryHosting\\.v1}' | grep "host:" | sed 's/ *host: *//')
+REGISTRY=$(kubectl get configmap -n kube-public local-registry-hosting -o=jsonpath='{.data.localRegistryHosting\\.v1}' | grep "host:" | sed 's/ *host: *//' | tr -d '"')
 if [ "$REGISTRY" != "" ]; then
   kubectl patch configmap/config-deployment \
     --namespace knative-serving \


### PR DESCRIPTION
In ubuntu microk8s patching configmap/config-deployment with local registry failed. The Tilt console showed a double quote after substituting $REGISTRY inside the patch command

this fixed the issue in my machine