### PR TITLE
feat: Add flag to configure tls scheme used by tunnels

### DIFF
--- a/ngrok/README.md
+++ b/ngrok/README.md
@@ -23,8 +23,12 @@ open tunnels at http://localhost:4040/.
 ## Flags
 
 `--auth=my-user:my-password`: Adds a basic auth prompt to all tunnels.
+
 `--default_config_file=~/.config/ngrok/my-default-config.yml`: Sets the path to the default configuration file for Ngrok. Default `~/.config/ngrok/ngrok.yml`.
+
 `--ngrok_config_version`: Sets the ngrok config version, use `1` for Ngrok Agent < v3, use `2` for Ngrok agent > v3. Default `2`.
+
+`--ngrok_config_tls_scheme`: Sets the protocol used by tunnels. Valid values are `http` and `https`. Default `http` for backward compatibility.
 
 ## Examples
 

--- a/ngrok/Tiltfile
+++ b/ngrok/Tiltfile
@@ -2,12 +2,14 @@
 config.define_string("auth")
 config.define_string("default_config_file")
 config.define_string("ngrok_config_version")
+config.define_string("ngrok_config_tls_scheme")
 cfg = config.parse()
 
 auth = cfg.get('auth', '')
 default_config_file = cfg.get('default_config_file', '')
 ngrok_config_version = cfg.get('ngrok_config_version', '2')
 config_file = str(local('mktemp "${TMPDIR:-/tmp}/tilt-ngrok.XXXXXXXXX"')).strip()
+ngrok_config_tls_scheme = cfg.get('ngrok_config_tls_scheme', 'http')
 
 local_resource(
   name='ngrok:status',
@@ -19,5 +21,5 @@ local_resource(
 local_resource(
   name='ngrok:operator',
   serve_cmd=['./ngrok-operator.sh', config_file],
-  serve_env={'TILT_NGROK_AUTH': auth, 'TILT_NGROK_CONFIG_VERSION': ngrok_config_version},
+  serve_env={'TILT_NGROK_AUTH': auth, 'TILT_NGROK_CONFIG_VERSION': ngrok_config_version, 'TILT_NGROK_CONFIG_TLS_SCHEME': ngrok_config_tls_scheme},
   deps=['./ngrok-operator.sh'])

--- a/ngrok/ngrok-reconcile-config.sh
+++ b/ngrok/ngrok-reconcile-config.sh
@@ -8,6 +8,7 @@
 
 auth_env="$TILT_NGROK_AUTH"
 config_version_env="$TILT_NGROK_CONFIG_VERSION"
+config_tls_scheme="$TILT_NGROK_CONFIG_TLS_SCHEME"
 
 set -euo pipefail
 
@@ -28,7 +29,7 @@ fi
 
 # Default v2 config
 tls_settings="schemes:
-      - http"
+      - $config_tls_scheme"
 
 if [[ "$config_version_env" == "1" ]]; then
   tls_settings="bind_tls: false"


### PR DESCRIPTION
Adding `--ngrok_config_tls_scheme` as an arg with a value of `https` will create https tunnels instead of http ones.