### PR TITLE
add retries to namespace test

### DIFF
--- a/namespace/test/job-default-namespace.yaml
+++ b/namespace/test/job-default-namespace.yaml
@@ -9,5 +9,5 @@ spec:
       containers:
       - name: namespace-test-verify
         image: curlimages/curl
-        command: ["curl",  "-fsSL", "http://namespace-test-busybox:8000/"]
+        command: ["curl", "--retry", "5", "-fsSL", "http://namespace-test-busybox:8000/"]
       restartPolicy: Never

--- a/namespace/test/job.yaml
+++ b/namespace/test/job.yaml
@@ -10,5 +10,5 @@ spec:
       containers:
       - name: namespace-test-verify
         image: curlimages/curl
-        command: ["curl",  "-fsSL", "http://namespace-test-busybox:8000/"]
+        command: ["curl",  "--retry", "5", "-fsSL", "http://namespace-test-busybox:8000/"]
       restartPolicy: Never


### PR DESCRIPTION
the test has gotten more flaky recently...

i wonder if job scheduling has just gotten faster, and so sometimes the test fails because dns isn't ready yet.