### PR TITLE
Support OCI helm registries

### DIFF
--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -83,11 +83,12 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
     def fetch_chart_details(chart, repo_name, auth, version):
         if repo_name.startswith('oci://'):
             command = build_helm_command(['show', 'chart', '%s/%s' % (repo_name, chart)], None, version)
+            results = decode_yaml(local(command, quiet=True))
+            return results
         else:
             command = build_helm_command(['search', 'repo', '%s/%s' % (repo_name, chart), '--output', 'yaml'], None, version)
-
-        results = decode_yaml(local(command, quiet=True))
-        return results[0] if type(results) == list else results
+            results = decode_yaml(local(command, quiet=True))
+            return results[0] if len(results) > 0 else None
 
     # ======== Condition Incoming Arguments
     if repo_name == '':

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -81,11 +81,13 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
         return args
 
     def fetch_chart_details(chart, repo_name, auth, version):
-        command = build_helm_command(['search', 'repo', '%s/%s' % (repo_name, chart), '--output', 'yaml'], None, version)
+        if repo_name.startswith('oci://'):
+            command = build_helm_command(['show', 'chart', '%s/%s' % (repo_name, chart)], None, version)
+        else:
+            command = build_helm_command(['search', 'repo', '%s/%s' % (repo_name, chart), '--output', 'yaml'], None, version)
+
         results = decode_yaml(local(command, quiet=True))
-
-        return results[0] if len(results) > 0 else None
-
+        return results[0] if type(results) == list else results
 
     # ======== Condition Incoming Arguments
     if repo_name == '':
@@ -110,7 +112,8 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
 
     if repo_name != chart and repo_name.replace('-', '').isalnum() == False or repo_name != repo_name.replace('.', ''):
         # https://helm.sh/docs/chart_best_practices/conventions/#chart-names
-        fail('Repo name is not valid')
+        if not repo_name.startswith('oci://'):
+            fail('Repo name is not valid')
 
     if version != 'latest' and version != version.replace('/', '').replace('\\', ''):
         fail('Version cannot contain a forward slash')


### PR DESCRIPTION
This PR introduces support for OCI registries like ECR to the helm_remote plugin. This fixes #457 

The only changes needed are to allow urls in the `repo_name` field and replace `helm search` with `helm show`.

https://helm.sh/docs/topics/registries/

Example:
```
helm_remote(
    'chart-name',
    repo_name='oci://835442211234.dkr.ecr.eu-west-1.amazonaws.com',
    release_name='my-namespace',
    values=['{}/values.yaml'.format(os.path.dirname(__file__))],
  )
```