### PR TITLE
dotenv: do not fail if file is missing

### DIFF
--- a/dotenv/Tiltfile
+++ b/dotenv/Tiltfile
@@ -1,5 +1,8 @@
-def dotenv(fn='.env'):
-	f = read_file(fn)
+def dotenv(fn='.env', required=True):
+	default = None
+	if not required:
+		default = ""
+	f = read_file(fn, default)
 	lines = str(f).splitlines()
 	for line in lines:
 		v = line.split('=', 1)


### PR DESCRIPTION
I've found that dotenv fails if the env file is missing because it uses read_file without a default.

Let me know if this is something that you'd consider!