### PR TITLE
github_token: new extension to retrieve GitHub PAT with GH CLI

### DIFF
--- a/github_token/README.md
+++ b/github_token/README.md
@@ -1,0 +1,19 @@
+# GitHub Token
+
+Author: [Nick Sieger](https://github.com/nicksieger)
+
+Ensure that the environment variable `$GITHUB_TOKEN` is set to a valid personal access token. Uses the GitHub CLI, if installed, to retrieve the token if none is set prior to launching Tilt.
+
+*Note*: Developer must already be logged in with `gh auth login` in order for token retrieval to be successful.
+
+## Function: `github_token`
+
+```
+github_token(
+  check_npm_packages: List[str]
+)
+```
+
+If `$GITHUB_TOKEN` is not already set, retrieve a token with the GitHub CLI.
+
+* `check_npm_packages`: if provided, checks that the developer has access to the given GHPR packages (scoped as `@org/package_name`). If packages cannot be accessed, prints a message telling the developer to re-auth with the `gh` command line and add scope `-s read:packages`.

--- a/github_token/Tiltfile
+++ b/github_token/Tiltfile
@@ -1,0 +1,44 @@
+def github_token(check_npm_packages=[]):
+    """
+    Return a GitHub personal access token (PAT), or fail. Attempts to use the
+    GitHub CLI if no token is provided in the environment. Also sets
+    $GITHUB_TOKEN inside the Tilt process.
+
+    Args:
+        check_npm_packages[List]: if provided, a list of scoped NPM packages (@org/pkg) to test access with the token.
+    """
+    token = os.getenv('GITHUB_TOKEN')
+    if token:
+        return token
+
+    auth_cmd = "run `gh auth login` to authenticate with GitHub"
+    if len(check_npm_packages) > 0:
+        auth_cmd = "run `gh auth login -s read:packages` to get a PAT with the correct scopes"
+
+    if not str(local(command='which gh || true',
+                     command_bat=['powershell', '-command', '& {get-command gh -erroraction silentlycontinue | format-list name}'],
+                     quiet=True)).strip():
+        fail("No $GITHUB_TOKEN found and GH CLI not installed;\n" +
+             "Please set $GITHUB_TOKEN with your PAT or\n" +
+             "install the GH CLI and %s" % auth_cmd)
+
+    token_line = str(local(command="gh auth status -t 2>&1 | grep Token:",
+                           command_bat=['powershell', '-command', '& {gh auth status -t 2>&1 | select-string -pattern "Token:" }'],
+                           quiet=True)).strip()
+    ind = token_line.find('Token:')
+    if ind == -1:
+        fail("Found GH CLI but not authorized with Github;\nPlease %s" % auth_cmd)
+    ind = ind + len('Token:')
+    token = token_line[ind:].strip()
+    os.putenv('GITHUB_TOKEN', token)
+
+    for pkg in check_npm_packages:
+        (org, slash, name) = pkg.partition("/")
+        if slash == "":
+            continue
+        org = org.removeprefix("@")
+        api_result = str(local(['gh', 'api', '/orgs/%s/packages/npm/%s' % (org, name), '--template', '{{.name}}'], quiet=True)).strip()
+        if api_result != name:
+            fail("GH CLI PAT is not authorized to read %s package;\nPlease %s" % (pkg, auth_cmd))
+
+    return token

--- a/github_token/test/Tiltfile
+++ b/github_token/test/Tiltfile
@@ -1,0 +1,31 @@
+# Note: there is intentionally no test.sh here; not attempting to configure and
+# use the GH CLI in CI. Run this manually with `tilt ci` when you have gh
+# installed and logged in.
+
+load('../Tiltfile', 'github_token')
+
+os.putenv('GITHUB_TOKEN', 'abc123')
+
+if github_token() != 'abc123':
+    fail("github_token() did not return existing token")
+
+os.unsetenv('GITHUB_TOKEN')
+
+token = github_token()
+if not token:
+    fail("github_token() did not return a token")
+if not os.getenv('GITHUB_TOKEN'):
+    fail("github_token() did not set $GITHUB_TOKEN")
+
+os.unsetenv('GITHUB_TOKEN')
+
+# Published public packages in GHPR are scarce. Here's one from GitHub that any
+# developer should be able to access.
+# https://github.com/github/template-parts/pkgs/npm/template-parts
+token = github_token(check_npm_packages=['@github/template-parts'])
+if not token:
+    fail("github_token() did not return a token")
+if not os.getenv('GITHUB_TOKEN'):
+    fail("github_token() did not set $GITHUB_TOKEN")
+
+local_resource('successful-test', 'true')


### PR DESCRIPTION
Extracting from an internal project Tiltfile to make it easy to use in multiple projects where a GitHub PAT secret is needed.