### PR TITLE
helm_resource: Add `auto_init` keyword argument

### DIFF
--- a/helm_resource/README.md
+++ b/helm_resource/README.md
@@ -32,7 +32,8 @@ def helm_resource(
     live_update=None,
     resource_deps=None,
     labels=None,
-    port_forwards=[]):
+    port_forwards=[],
+    auto_init=True):
   ...
 ```
 
@@ -84,6 +85,8 @@ chart. Must be the same length as `image_deps`.  There are two common patterns.
 `labels`: Labels for categorizing the resource.
 
 `port_forwards`: Host port to connect to the pod. Takes the same form as `port_forwards` in [the `k8s_resource` command](https://docs.tilt.dev/api.html#api.k8s_resource).
+
+`auto_init`: Whether this resource runs on `tilt up`. Defaults to `True`. For more info, see the [Manual Update Control docs](https://docs.tilt.dev/manual_update_control.html).
 
 ### helm_repo
 

--- a/helm_resource/Tiltfile
+++ b/helm_resource/Tiltfile
@@ -19,7 +19,8 @@ def helm_resource(
     live_update=None,
     resource_deps=None,
     labels=None,
-    port_forwards=[]):
+    port_forwards=[],
+    auto_init=True):
   """Installs a helm chart to a cluster.
 
   Args:
@@ -56,6 +57,7 @@ def helm_resource(
       adding a dependency on a helm repo install.
     labels: Labels for categorizing the resource.
     port_forwards: Host port to connect to the pod.
+    auto_init: Whether this resource runs on `tilt up`. Defaults to `True`.
   """
 
   if not release_name:
@@ -119,6 +121,9 @@ def helm_resource(
 
   if len(port_forwards):
     k8s_resource(name, port_forwards=port_forwards)
+
+  if not auto_init:
+    k8s_resource(name, auto_init=auto_init)
 
 
 def helm_repo(


### PR DESCRIPTION
Include support for the `auto_init` keyword argument from [`k8s_resource`][0].

The use-case is our team wants to be able to run a service from a Helm chart in our cluster, but it is not critical to the functionality of the cluster and incurs a significant performance cost. We would like to be able opt-out of starting this heavy service automatically when running `tilt up`.

No tests are included because I'm not certain how to test that a resource _doesn't_ exist in a meaningful way.

[0]: https://docs.tilt.dev/api.html#api.k8s_resource