### PR TITLE
[Feature] Add rsync tilt path

### DIFF
--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -5,13 +5,16 @@ krsync_path = os.path.join(os.getcwd(), 'krsync.sh')
 MIN_LOCAL_RSYNC_VERSION = '3.0.0'
 verify_rsync_path = os.path.join(os.getcwd(), 'verify_rsync.sh')
 
+# Path on the remote container where the rsync binary is located
+rsync_path = '/bin/rsync.tilt'
+
 # if no local rsync/insufficient version, bail
 print('-- syncback extension checking for local rsync --')
 local([verify_rsync_path, MIN_LOCAL_RSYNC_VERSION])
 
 DEFAULT_EXCLUDES = ['.git', '.gitignore', '.dockerignore', 'Dockerfile', '.tiltignore', 'Tiltfile', 'tilt_modules']
 
-def syncback_command_args(k8s_object, src_dir, ignore=None, delete=False, paths=None, target_dir='.', container='', namespace='', verbose=False):
+def syncback_command_args(k8s_object, src_dir, ignore=None, delete=False, paths=None, target_dir='.', container='', namespace='', verbose=False, rsync_path=rsync_path):
     """
     Generate a list of command arguments to run that will sync the specified files from the given k8s object to the local filesystem.
     :param k8s_object (str): a Kubernetes object identifier (e.g. deploy/my-deploy, job/my-job, or a pod ID) that Tilt
@@ -30,6 +33,7 @@ def syncback_command_args(k8s_object, src_dir, ignore=None, delete=False, paths=
     :param container (str, optiona): name of the container to sync from (by default, the first container)
     :param namespace (str, optiona): namespace of the desired k8s_object, if not `default`.
     :param verbose (bool, optional): if true, print additional rsync information.
+    :param rsync_path (str, optional): A path where the remote containers `rsync` executable is located. Defaults to `/bin/rsync.tilt`.
     """
     # Verify inputs
     if not src_dir.endswith('/'):
@@ -82,6 +86,7 @@ def syncback_command_args(k8s_object, src_dir, ignore=None, delete=False, paths=
     argv = [
         krsync_path,
         k8s_object,
+        rsync_path,
         flags,
         '--progress',
         '--stats',
@@ -95,15 +100,15 @@ def syncback_command_args(k8s_object, src_dir, ignore=None, delete=False, paths=
     return argv
 
 
-def syncback_command(k8s_object, src_dir, ignore=None, delete=False, paths=None, target_dir='.', container='', namespace='', verbose=False):
+def syncback_command(k8s_object, src_dir, ignore=None, delete=False, paths=None, target_dir='.', container='', namespace='', verbose=False, rsync_path=rsync_path):
     """
     Generate a properly-quoted shell command string that will sync the specified files from the given k8s object to the local filesystem.
     """
-    argv = syncback_command_args(k8s_object, src_dir, ignore, delete, paths, target_dir, container, namespace, verbose)
+    argv = syncback_command_args(k8s_object, src_dir, ignore, delete, paths, target_dir, container, namespace, verbose, rsync_path)
     return ' '.join([shlex.quote(arg) for arg in argv])
 
 
-def syncback(name, k8s_object, src_dir, ignore=None, delete=False, paths=None, target_dir='.', container='', namespace='', verbose=False, labels=[], resource_deps=[]):
+def syncback(name, k8s_object, src_dir, ignore=None, delete=False, paths=None, target_dir='.', container='', namespace='', verbose=False, labels=[], resource_deps=[], rsync_path=rsync_path):
     """
     Create a local resource that will (via rsync) sync the specified files
     from the specified k8s object to the local filesystem.
@@ -127,6 +132,7 @@ def syncback(name, k8s_object, src_dir, ignore=None, delete=False, paths=None, t
     :param verbose (bool, optional): if true, print additional rsync information.
     :param labels (Union[str, List[str]], optional): Used to group resources in the Web UI.
     :param resource_deps (Union[str, List[str]], optional): Used to declare dependencies on other resources.
+    :param rsync_path (str, optional): A path where the remote containers `rsync` executable is located. Defaults to `/bin/rsync.tilt`.
     """
     # Ensure extra kwargs are only passed to local_resource if specified to
     # provide backward compatibility with older version of tilt.
@@ -135,7 +141,7 @@ def syncback(name, k8s_object, src_dir, ignore=None, delete=False, paths=None, t
                                ignore=ignore, delete=delete, paths=paths,
                                target_dir=target_dir,
                                container=container, namespace=namespace,
-                               verbose=verbose)
+                               verbose=verbose, rsync_path=rsync_path)
     extra_args = {}
 
     if labels:


### PR DESCRIPTION
Adds functionality to customize the rsync path on the container to resolve potential permission errors if the execution user does not have permission to modify the containers `/bin` directory. Resolves https://github.com/tilt-dev/tilt-extensions/issues/478

Adds the `tilt_rsync_path` parameter to the `syncback` command.

Used like:

```
syncback("python-syncback", 
    "deploy/syncback-containers", 
    "/root/", 
    paths=['main.py'],  
    target_dir=python, 
    container="python", 
    namespace="syncback-test",
    rsync_path="/some/remote/path/"
)
```