### PR TITLE
helm_resource: Make helm-delete-helper quieter

### DIFF
--- a/helm_resource/helm-delete-helper.py
+++ b/helm_resource/helm-delete-helper.py
@@ -7,13 +7,18 @@ import os
 import subprocess
 import sys
 
-delete_cmd = ['helm', 'uninstall']
+release_name = os.environ['RELEASE_NAME']
 namespace = os.environ.get('NAMESPACE', '')
-if namespace:
-  delete_cmd.extend(['--namespace', namespace])
+namespace_args = ('--namespace', namespace) if namespace else ()
 
-delete_cmd.extend([os.environ['RELEASE_NAME']])
-
-# ignore error code.
-print("Running cmd: %s" % delete_cmd, file=sys.stderr)
-subprocess.call(delete_cmd)
+# Check that release exists before uninstalling it
+status_cmd = ('helm', 'status') + namespace_args + (release_name,)
+status_result = subprocess.call(
+  status_cmd,
+  stdout=subprocess.DEVNULL,
+  stderr=subprocess.DEVNULL,
+)
+if status_result == 0:
+    delete_cmd = ('helm', 'uninstall') + namespace_args + (release_name,)
+    print('Running cmd: %s' % ' '.join(delete_cmd), file=sys.stderr)
+    subprocess.call(delete_cmd)

--- a/helm_resource/test/Tiltfile
+++ b/helm_resource/test/Tiltfile
@@ -90,3 +90,10 @@ helm_resource(
   'bitnami/memcached',
   labels=['memcached'],
   resource_deps=['helm-repo-bitnami'])
+
+helm_resource(
+  'memcached-no-init',
+  'bitnami/memcached',
+  labels=['memcached'],
+  resource_deps=['helm-repo-bitnami'],
+  auto_init=False)


### PR DESCRIPTION
This PR makes `helm-delete-helper` smarter by checking if a release is installed _before_ trying to uninstall it.

After #471 was merged, it's possible for Helm releases to be known to Tilt, but not actually running in the cluster. This means that when `tilt down` is called, the [`helm uninstall`][0] command run by `helm-delete-helper` will fail with an error like:

> Error: uninstall: Release not loaded: kafka-operator: release: not found

While these errors are harmless, they are noisy and can appear as if Tilt itself is failing. This PR aims to remove those errors altogether by calling [`helm status`][1] first and checking that it was successful before calling `helm uninstall`.

The rest of the code was also refactored to be simpler.

To test this, run the `/helm_resource/tests/test.sh`. When it tears down the resources it created, this error should not appear:

> Error: uninstall: Release not loaded: memcached-no-init: release: not found

[0]: https://helm.sh/docs/helm/helm_uninstall/
[1]: https://helm.sh/docs/helm/helm_status/