### PR TITLE
git_resource: add no-single-branch flag for shallow clones

### DIFF
--- a/git_resource/Tiltfile
+++ b/git_resource/Tiltfile
@@ -53,7 +53,7 @@ def git_checkout(repository_url, checkout_dir=None, unsafe_mode=False):
         if not os.path.exists(checkout_dir):  # needs clone
             clone_cmd = ['git','clone', repository_url, '--recurse-submodules', '--shallow-submodules']
             if is_branch or is_tag:
-                clone_cmd.extend(['--depth', '1'])
+                clone_cmd.extend(['--depth', '1', '--no-single-branch'])
                 if tree:
                     clone_cmd.extend(['--branch', tree])
                 clone_cmd.append(checkout_dir)


### PR DESCRIPTION
Currently if you reference a repo with a branch,then change that branch it will fail with an error of 'No such reference'. This is because since version 1.8, Git shallow clones only pull a single branch [1]. There was a flag added (--no-single-branch) to pull all branches.

[1] https://stackoverflow.com/questions/23708231/git-shallow-clone-clone-depth-misses-remote-branches