### PR TITLE
Add example for values file to helm_resource

### DIFF
--- a/helm_resource/README.md
+++ b/helm_resource/README.md
@@ -75,6 +75,8 @@ chart. Must be the same length as `image_deps`.  There are two common patterns.
 
 - Pass a version as `flags=['--version=1.0.0']`.
 
+- Pass a values file as `flags=['--values=./path/to/values.yaml']`.
+
 `image_selector`: Image reference to determine containers eligible for Live Update.
   Only applicable if there are no images in `image_deps`.
   


### PR DESCRIPTION
Took the example from https://github.com/tilt-dev/tilt-extensions/issues/370#issuecomment-1184961535, I'd argue that this is a very common case for remote repositories. I was almost going to use helm_remote because I couldn't find this functionality until I stumbled upon this comment.

It might not be a problem for people experienced in Helm, for Helm newbies I think it's good to be there