### PR TITLE
feat: k8s_yaml_glob extension for loading manifests by glob patterns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`honeycomb`](/honeycomb): Report dev env performance to [Honeycomb](https://honeycomb.io).
 - [`jest_test_runner`](/jest_test_runner): Jest JavaScript test runner. Example from [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).
 - [`k8s_attach`](/k8s_attach): Attach to an existing Kubernetes resource that's already in your cluster. View their health and live-update them in-place.
+- [`k8s_yaml_glob`](/k8s_yaml_glob): Load kubernetes manifests by glob patterns.
 - [`kim`](/kim): Use [kim](https://github.com/rancher/kim) to build images for Tilt
 - [`knative`](/knative): Use [knative serving](https://knative.dev/docs/serving/) to iterate on scale-to-zero servers.
 - [`ko`](/ko): Use [Ko](https://github.com/google/ko) to build Go-based container images

--- a/k8s_yaml_glob/README.md
+++ b/k8s_yaml_glob/README.md
@@ -1,0 +1,22 @@
+# Kubernetes YAML Glob
+
+Author: [Glenn Franxman](https://github.com/gfranxman)
+
+Load kubernetes manifests by glob patterns.
+
+## Usage
+
+First load the extension like:
+
+    load('ext://k8s_yaml_glob', 'k8s_yaml_glob')
+    
+Then use it like this:
+
+    # all of the .yaml files in the k8s directory.
+    k8s_yaml_glob('./k8s/*.yaml')  
+    
+or like this:
+
+    # all of the dev-*.yaml files in the k8s directory and subdirectories.
+    k8s_yaml_glob('./k8s/**/dev-*.yaml')  
+    

--- a/k8s_yaml_glob/Tiltfile
+++ b/k8s_yaml_glob/Tiltfile
@@ -1,0 +1,16 @@
+# -*- mode: Python -*-
+
+def k8s_yaml_glob(*glob_patterns, **kwargs):
+    """
+    Create/apply list of Kubernetes YAML files matching the given glob patterns.
+    """
+
+    is_windows = True if os.name == "nt" else False
+    python_cmd = 'py -3' if is_windows else 'python3'
+
+    for glob_pattern in glob_patterns:
+        script = 'import glob; print("|".join( p for p in glob.glob(\"' + glob_pattern + '")))'
+        cmd = python_cmd + " -c '" + script + "'"
+        val = str(local(command=python_cmd + " -c '" + script + "'", quiet=False)).strip()
+        yaml_paths = val.split("|")
+        k8s_yaml(yaml_paths, **kwargs)


### PR DESCRIPTION
A simple extension to facilitate loading subsets of manifests by directory and filename patterns.


## Usage

First load the extension like:

    load('ext://k8s_yaml_glob', 'k8s_yaml_glob')
    
Then use it like this:

    # all of the .yaml files in the k8s directory.
    k8s_yaml_glob('./k8s/*.yaml')  
    
or like this:

    # all of the dev-*.yaml files in the k8s directory and subdirectories.
    k8s_yaml_glob('./k8s/**/dev-*.yaml')  