### PR TITLE
Validate flag for helm_remote extension

### DIFF
--- a/helm_remote/README.md
+++ b/helm_remote/README.md
@@ -16,7 +16,7 @@ helm_remote('myChartName')
 ##### Additional Parameters
 
 ```
-helm_remote(chart, repo_url='', repo_name='', release_name='', namespace='', version='', username='', password='', values=[], set=[])
+helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], set=[], namespace='', version='', username='', password='', allow_duplicates=False, create_namespace=False, validate=False)
 ```
 
 * `chart` ( str ) – the name of the chart to install  
@@ -31,6 +31,7 @@ helm_remote(chart, repo_url='', repo_name='', release_name='', namespace='', ver
 * `password` ( str ) – repository authentication password, if needed (equivalent to helm's `--password` flag)
 * `values` ( Union [ str , List [ str ]]) – Specify one or more values files (in addition to the values.yaml file in the chart). Equivalent to the helm's `--values` or `-f` flags
 * `set` ( Union [ str , List [ str ]]) – Directly specify one or more values (equivalent to helm's `--set` flag)
+* `validate` - Validates Kubernetes version of the server (equivalent to helm's `--validate` flag)
 * `allow_duplicates` ( bool ) - Allow duplicate resources. Usually duplicate resources indicate a programmer error.
    But some charts specify resources twice.
 * `create_namespace` ( bool ) - Create the namespace specified in `namespace` ( equivalent to helm's `--create_namespace` flag)

--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -54,7 +54,10 @@ metadata:
 #   =====================================
 
 
-def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], set=[], namespace='', version='', username='', password='', allow_duplicates=False, create_namespace=False):
+def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], set=[], namespace='', version='', username='', password='', allow_duplicates=False, create_namespace=False, validate=False):
+    values = [values] if type(values) == type('') else values
+    set = [set] if type(set) == type('') else set
+
     # ======== Helper methods
     def get_local_repo(repo_name, repo_url):
         # if no repos are present, helm exit code is >0 and stderr output buffered
@@ -178,7 +181,21 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
     # TODO: since neither `k8s_yaml()` nor `helm()` accept resource_deps,
     # sometimes the crds haven't yet finished installing before the below tries
     # to run
-    yaml = helm(chart_target, name=release_name, namespace=namespace, values=values, set=set)
+    helm_tpl_cmd = ['template', release_name, chart_target, '--include-crds', '--namespace', namespace]
+
+    if len(values) != 0:
+        for v in values:
+            helm_tpl_cmd.extend(['--values', v])
+
+    if len(set) != 0:
+        for s in set:
+            helm_tpl_cmd.extend(['--set', s])
+
+    if validate:
+        helm_tpl_cmd.append('--validate')
+
+
+    yaml = local(build_helm_command(helm_tpl_cmd, None, None))
 
     # The allow_duplicates API is only available in 0.17.1+
     if allow_duplicates and _version_tuple() >= [0, 17, 1]:
@@ -217,3 +234,4 @@ def install_crds(name, directory):
 
         # TODO: Figure out how to avoid another named resource showing up in the tilt HUD for this waiter
         local_resource(name+'-ready', resource_deps=[name+'-install'], cmd='kubectl wait --for=condition=Established crd --all')  # now we can wait for those crds to finish establishing
+


### PR DESCRIPTION
I have found an issue with one of our Helm charts. 

`Error: chart requires kubeVersion: >=1.21.0-0 which is incompatible with Kubernetes v1.20.0\n\nUse --debug flag to render out invalid YAML`

My Kubernetes version is `1.25.3`, so I suspected `helm`. Here is the solution: https://github.com/helm/helm/issues/10086#issuecomment-909595139

But the case is Tilt built in `helm` function doesn't support validate flag, so this change uses a custom `template` command which optionally validate-able.