### PR TITLE
Fix kubectl_build command

### DIFF
--- a/kubectl_build/Tiltfile
+++ b/kubectl_build/Tiltfile
@@ -61,7 +61,8 @@ def kubectl_build(ref, context, build_args={}, dockerfile=None,
         dockerfile_path = context + '/Dockerfile'
 
     registry_secret = registry_secret or kubectl_build_registry_secret()
-    command = ['kubectl', 'build', '--context', k8s_context()]
+    # "kubectl build" is the binary and the second "build" is the subcommand
+    command = ['kubectl', 'build', 'build', '--context', k8s_context()]
     command += ['-f', dockerfile_path]
     if registry_secret:
         command += ['--registry-secret', registry_secret]


### PR DESCRIPTION
I had an issue with the `kubectl_build` extension: `kubectl build <context> …` made the CLI considere the `<context>` is the subcommand (as `kubectl build` has multiple commands: `create`, `rm`, `ls`…).

I fixed it by changing the `kubectl build …` command to `kubectl build build …`.