### PR TITLE
feat(procfile): allow passing kwargs to local_resource

### DIFF
--- a/procfile/Tiltfile
+++ b/procfile/Tiltfile
@@ -1,4 +1,4 @@
-def procfile_resources(procfile='Procfile', set_port=False, starting_port=5000):
+def procfile_resources(procfile='Procfile', set_port=False, starting_port=5000, **kwargs):
   """
   Creates local resources from a Procfile (e.g., as defined by Foreman: http://blog.daviddollar.org/2011/05/06/introducing-foreman.html)
 
@@ -18,5 +18,5 @@ def procfile_resources(procfile='Procfile', set_port=False, starting_port=5000):
       # show up in logs as the command being run (and then we could default
       # set_port to True)
       cmd = 'PORT=%d %s' % (port, cmd)
-    local_resource(name, serve_cmd=cmd)
+    local_resource(name, serve_cmd=cmd, **kwargs)
     port += 1

--- a/procfile/test/Procfile
+++ b/procfile/test/Procfile
@@ -1,0 +1,1 @@
+one: echo "foo" && sleep 100

--- a/procfile/test/Procfile.two
+++ b/procfile/test/Procfile.two
@@ -1,0 +1,1 @@
+two: echo "bar" && sleep 100

--- a/procfile/test/Tiltfile
+++ b/procfile/test/Tiltfile
@@ -1,0 +1,7 @@
+load('../Tiltfile', 'procfile_resources', )
+
+# default usage
+procfile_resources()
+
+# pass args to local_resource
+procfile_resources('Procfile.two', labels=["foo", "bar"])

--- a/procfile/test/test.sh
+++ b/procfile/test/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+cd "$(dirname "$0")" || exit
+
+set -euo pipefail
+
+OUTPUT="$(tilt ci)"
+
+if ! (echo "$OUTPUT" | grep -q foo); then
+  echo "did not find string 'foo' in output"
+  echo "output:"
+  echo
+  echo "$OUTPUT"
+  exit 1
+fi
+
+if ! (echo "$OUTPUT" | grep -q bar); then
+  echo "did not find string 'bar' in output"
+  echo "output:"
+  echo
+  echo "$OUTPUT"
+  exit 1
+fi


### PR DESCRIPTION
Hi team,

Small change to allow passing kwargs to local_resource. Enable things like Labels or AutoInit=False on Procfile resources.

I'm not sure how to add tests, if needed. Happy to have some guidances.

Cheers