### PR TITLE
fix(min_k8s_version): Remove --short flag for kubectl version

### DIFF
--- a/min_k8s_version/README.md
+++ b/min_k8s_version/README.md
@@ -4,6 +4,10 @@ Specify a minimum Kubenetes version to run this TiltFile
 
 If the minimum version is not met, Tilt will stop executing using the `fail` api
 
+## Requirements
+
+- kubectl v1.28+
+
 ## Usage
 
 

--- a/min_k8s_version/Tiltfile
+++ b/min_k8s_version/Tiltfile
@@ -37,7 +37,7 @@ def _get_server_version():
     #
     # The previous version used 'grep' to filter out the server version. Use a
     # native way to support systems without 'grep'.
-    kubectl_version_output = str(local('kubectl version --short', quiet=True))
+    kubectl_version_output = str(local('kubectl version', quiet=True))
     version_str = ''
     for line in kubectl_version_output.split('\n'):
         if line.startswith('Server Version'):


### PR DESCRIPTION
Context:
- kubectl deprecated `--short` flag for `kubectl version` at `v1.24` https://github.com/kubernetes/kubernetes/pull/108987
- kubectl removed `--short` flag for `kubectl version` at `v1.28` https://github.com/kubernetes/kubernetes/pull/116720
- currently we have an error in the below with kubectl v1.28
- default output is changed as same as `--short` flag

```
Error in local: command "kubectl version --short" failed.
error: exit status 1
stdout: ""
stderr: "error: unknown flag: --short\nSee 'kubectl version --help' for usage.\n"
```

Changes:
- removed `--short` flag for `kubectl version` in `min_k8s_version`
- min_k8s_version requires kubectl `v1.28+ `