### PR TITLE
Fix min version issue with k8s client

### DIFF
--- a/min_k8s_version/Tiltfile
+++ b/min_k8s_version/Tiltfile
@@ -37,6 +37,19 @@ def _get_server_version():
     #
     # The previous version used 'grep' to filter out the server version. Use a
     # native way to support systems without 'grep'.
+    kubectl_version_output = str(local('kubectl version', quiet=True))
+    for line in kubectl_version_output.split('\n'):
+        if line.startswith('Server Version'):
+            version_string = line.split(':')[1].strip()
+            if version_string.startswith('version.Info'):
+               # we are pre 1.28 kubectl, let's use the old method
+               return _get_server_version_pre_1_28_kubectl()
+            else:
+               return version_string.replace('v', '')
+            
+    return ""
+
+def _get_server_version_pre_1_28_kubectl():   
     kubectl_version_output = str(local('kubectl version --short', quiet=True))
     version_str = ''
     for line in kubectl_version_output.split('\n'):


### PR DESCRIPTION
Context:
- kubectl deprecated --short flag for kubectl version at v1.24 https://github.com/kubernetes/kubernetes/pull/108987
- kubectl removed --short flag for kubectl version at v1.28 https://github.com/kubernetes/kubernetes/pull/116720

currently we have an error in the below with kubectl v1.28
default output is changed as same as --short flag
```
Error in local: command "kubectl version --short" failed.
error: exit status 1
stdout: ""
stderr: "error: unknown flag: --short\nSee 'kubectl version --help' for usage.\n"
```

Verified and works with kubectl v1.27 and 1.28 too.

Changes:
We support both versions of k8s by trying first the normal path, and if we get the old output back (that always starts with a version.Info string), then we fall back to the old logic.

This is a less restrictive version of https://github.com/tilt-dev/tilt-extensions/pull/520 in regard the k8s version requirement.