### PR TITLE
add pod_readiness flag to helm_resource

### DIFF
--- a/helm_resource/Tiltfile
+++ b/helm_resource/Tiltfile
@@ -20,7 +20,8 @@ def helm_resource(
     resource_deps=None,
     labels=None,
     port_forwards=[],
-    auto_init=True):
+    auto_init=True,
+    pod_readiness=''):
   """Installs a helm chart to a cluster.
 
   Args:
@@ -58,8 +59,11 @@ def helm_resource(
     labels: Labels for categorizing the resource.
     port_forwards: Host port to connect to the pod.
     auto_init: Whether this resource runs on `tilt up`. Defaults to `True`.
+    pod_readiness: Possible values: 'ignore', 'wait'. Controls whether Tilt waits for
+      pods to be ready before the resource is considered healthy (and dependencies
+      can start building). By default, Tilt will wait for pods to be ready if it
+      thinks a resource has pods.
   """
-
   if not release_name:
     release_name=name
 
@@ -124,6 +128,9 @@ def helm_resource(
 
   if not auto_init:
     k8s_resource(name, auto_init=auto_init)
+
+  if pod_readiness:
+    k8s_resource(name, pod_readiness = pod_readiness)
 
 
 def helm_repo(


### PR DESCRIPTION
Simple fix, I was tired of seeing my helm_resources without pods be stuck in the UI.