### PR TITLE
helm_remote: fix pulling oci helm charts on windows

### DIFF
--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -145,7 +145,7 @@ def helm_remote(chart, repo_url='', repo_name='', release_name='', values=[], se
 
     # ======== Initialize
     # -------- targets
-    pull_target = os.path.join(helm_remote_cache_dir, repo_name, version)
+    pull_target = os.path.join(helm_remote_cache_dir, repo_name.replace(':', ''), version)
     chart_target = os.path.join(pull_target, chart)
 
     cached_chart_exists = os.path.exists(chart_target)


### PR DESCRIPTION
previously it would create a target path like
"..\\AppData\\Local\\tilt-dev\\.helm\\oci:\\repo.net:1234\\chart\\latest" which is not a valid path on windows. so now we just strip every :