### PR TITLE
fix(kubebuilder): Update go.main path

### DIFF
--- a/kubebuilder/Tiltfile
+++ b/kubebuilder/Tiltfile
@@ -36,7 +36,7 @@ def kubebuilder(DOMAIN, GROUP, VERSION, KIND, IMG='controller:latest', CONTROLLE
     
     # build to tilt_bin beause kubebuilder has a dockerignore for bin/
     def binary():
-        return 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o tilt_bin/manager main.go'
+        return 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o tilt_bin/manager cmd/main.go'
 
     installed = local("which kubebuilder")
     print("kubebuilder is present:", installed)

--- a/kubebuilder/Tiltfile
+++ b/kubebuilder/Tiltfile
@@ -58,7 +58,7 @@ def kubebuilder(DOMAIN, GROUP, VERSION, KIND, IMG='controller:latest', CONTROLLE
     
     k8s_yaml(yaml())
     
-    deps = ['controllers', 'main.go']
+    deps = ['internal/controller', 'cmd/main.go']
     deps.append('api')
     
     local_resource('Watch&Compile', generate() + binary(), deps=deps, ignore=['*/*/zz_generated.deepcopy.go'])


### PR DESCRIPTION
Kubebuilder 3.13 puts the go.main in cmd/