### PR TITLE
fix: pass through 'platform' arg to nerdctl

### DIFF
--- a/nerdctl/Tiltfile
+++ b/nerdctl/Tiltfile
@@ -51,6 +51,9 @@ def nerdctl_build(
 
     if secret:
         cmd += ['--secret', secret]
+    
+    if platform:
+        cmd += ['--platform', platform]
 
     if extra_tag:
         if type(extra_tag) == 'string':


### PR DESCRIPTION
The `nerdctl` extension was not passing through the `platform` argument to the under lying command. 

tested locally with the following example

```
nerdctl_build(
  ref='my-docker-image', 
  context='.',
  platform='amd64'
)
```

output observed in the Tilt UI

```
Running cmd: nerdctl --namespace k8s.io build --platform amd64 -t "${EXPECTED_REF}" .
```