### PR TITLE
Add base64 extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`uibutton`](/uibutton): Customize your Tilt dashboard with [buttons to run a command](https://blog.tilt.dev/2021/06/21/uibutton.html).
 - [`vault_client`](/vault_client): Reach secrets from a Vault instance.
 - [`wait_for_it`](/wait_for_it): Wait until command output is equal to given output.
+- [`base64`](/base64): Base64 encode or decode a string.
 
 ## Contribute an Extension
 

--- a/base64/README.md
+++ b/base64/README.md
@@ -1,0 +1,21 @@
+# Base64
+
+Author: [Remi Rampin](https://github.com/remram44)
+
+## Functions
+
+### encode_base64
+
+```
+encode_base64(content: str): str
+```
+
+Takes the given string and returns it as a base64-encoded string with padding.
+
+### decode_base64
+
+```
+decode_base64(content: str): str
+```
+
+Takes the given base64-encoded string and decodes it to its content.

--- a/base64/Tiltfile
+++ b/base64/Tiltfile
@@ -1,0 +1,17 @@
+def encode_base64(content):
+    return str(local(
+        command=['base64', '-w', '0'],
+        command_bat=['powershell', '[convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($input))'],
+        quiet=True,
+        echo_off=True,
+        stdin=content,
+    )).strip()
+
+def decode_base64(content):
+    return str(local(
+        command=['base64', '-d'],
+        command_bat=['powershell', '[Text.Encoding]::UTF8.GetString([convert]::FromBase64String($input))'],
+        quiet=True,
+        echo_off=True,
+        stdin=content,
+    ))


### PR DESCRIPTION
It looks like the PowerShell version strips newlines inside the content, I am not sure it can be avoided. Unless we want to build the function natively, which I think we should.

Closes #538