### PR TITLE
circleci: update to go 1.21

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -7,6 +7,7 @@ RUN apt update \
       build-essential \
       ca-certificates \
       git \
+      gnupg-agent \
       jq \
       netcat-traditional \
       software-properties-common \
@@ -17,7 +18,7 @@ RUN apt update \
 RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
 # Install Go toolchain
-COPY --from=golang:1.20-bullseye /usr/local/go /usr/local/go
+COPY --from=golang:1.21-bullseye /usr/local/go /usr/local/go
 ENV PATH=/root/go/bin:/usr/local/go/bin:$PATH
 
 # install Ko
@@ -40,9 +41,10 @@ RUN curl -sSL "https://github.com/buildpacks/pack/releases/download/${PACK_VERSI
 # install nodejs + yarn
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt update && \
     apt install -y -q --no-install-recommends \
-      default-jdk \
       nodejs \
       yarn
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   validate:
     docker:
-      - image: docker/tilt-extensions-ci@sha256:d015e9e5cc5a3dce9fa258b1d6b8cb593c9a42c0efef2239419ceed29f874d0f
+      - image: docker/tilt-extensions-ci@sha256:140746f2ee1b55fc03f3d6f63d31eb766de0b1478a74cc4d1c55204f2807ef36
 
     steps:
       - checkout
@@ -11,7 +11,7 @@ jobs:
 
   shellcheck:
     docker:
-      - image: docker/tilt-extensions-ci@sha256:d015e9e5cc5a3dce9fa258b1d6b8cb593c9a42c0efef2239419ceed29f874d0f
+      - image: docker/tilt-extensions-ci@sha256:140746f2ee1b55fc03f3d6f63d31eb766de0b1478a74cc4d1c55204f2807ef36
 
     steps:
       - checkout
@@ -22,7 +22,7 @@ jobs:
     # spaces in paths, which is common on macOS (/Application Support/)
     working_directory: ~/tilt extensions
     docker:
-      - image: docker/tilt-extensions-ci@sha256:d015e9e5cc5a3dce9fa258b1d6b8cb593c9a42c0efef2239419ceed29f874d0f
+      - image: docker/tilt-extensions-ci@sha256:140746f2ee1b55fc03f3d6f63d31eb766de0b1478a74cc4d1c55204f2807ef36
 
     steps:
       - setup_remote_docker


### PR DESCRIPTION
Signed-off-by: Nick Santos <nick.santos@docker.com>
