### PR TITLE
[kubebuilder] Remove GOARCH to make it work on the Apple Silicon（M1/M2) env

### DIFF
--- a/kubebuilder/Tiltfile
+++ b/kubebuilder/Tiltfile
@@ -36,7 +36,7 @@ def kubebuilder(DOMAIN, GROUP, VERSION, KIND, IMG='controller:latest', CONTROLLE
     
     # build to tilt_bin beause kubebuilder has a dockerignore for bin/
     def binary():
-        return 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o tilt_bin/manager cmd/main.go'
+        return 'CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -o tilt_bin/manager cmd/main.go'
 
     installed = local("which kubebuilder")
     print("kubebuilder is present:", installed)


### PR DESCRIPTION
## change
- [kubebuilder] Remove GOARCH to make it work on the Apple Silicon（M1/M2）env

## test
- I confirmed that this works on both the linux amd64 env and the darwin arm64 env.