### PR TITLE
`vault_client`: Fix extention name typo in example

### DIFF
--- a/vault_client/README.md
+++ b/vault_client/README.md
@@ -25,7 +25,7 @@ Under the hood, it is doing te command `vault read -field=$fiel $path"`
 ## Example Usage
 
 ```
-load('ext://vault_cli', 'vault_read_secret', 'vault_set_env_vars')
+load('ext://vault_client', 'vault_read_secret', 'vault_set_env_vars')
 vault_set_env_vars('https://localhost:8200','mytoken')
 my_foo = vault_read_secret('path/myfoo', 'value')
 my_bar = vault_read_secret('path/mybar', 'foobar')


### PR DESCRIPTION
The extension name seem to be `vault_client` instead of `vault_cli`

![error message](https://github.com/tilt-dev/tilt.build/assets/12410942/ed165306-6170-4631-b53d-e7b16948db55)