### PR TITLE
logger: add logger extension

### DIFF
--- a/logger/README.md
+++ b/logger/README.md
@@ -1,0 +1,152 @@
+# Logger
+
+Author: [Nico Braun](https://github.com/gebinic)
+
+Simple and customizable logger. The logger respects the typical hierarchy of log levels. A log level can be customized with the environment variable `LOGGER_LOG_LEVEL`, default: `info`. Each log function (`debug`, `info`, `warning` and `error`) automatically checks, if the corresponding log level is enabled. All of the functions below are published as `logger` struct.
+
+Log level hierarchy:
+
+```
+debug -> "debug", "info", "warning" and "error"
+info -> "info", "warning" and "error"
+warning -> "warning" and "error"
+error -> "error" only
+```
+
+Optionally, line separators (i.e. log separators) can be used *before* **and** *after* the log line. This behavior can be controlled either with function parameters or the environment variable `LOGGER_USE_LOG_SEPARATOR` (must be `True` or `False` (case insensitive), default: `False`). The log separator itself can be customized with the environment variable `LOGGER_LOG_SEPARATOR`, default: ``'\n' + '*' * 20 + '\n'``. Example with log separator (error logging):
+
+```
+Loading Tiltfile at: /path/to/Tiltfile
+Traceback (most recent call last):
+  /path/to/Tiltfile:12:6: in <toplevel>
+Error in my_function: 
+********************
+My error log
+********************
+```
+
+## Functions
+
+### is_debug_enabled
+
+```
+is_debug_enabled(): bool
+```
+
+Whether debug logging is enabled.
+
+### debug
+
+```
+debug(content: str, use_log_separator: bool): None
+```
+
+Prints debug log.
+
+* `content (str)` - the content to be logged
+* `use_log_separator` - whether a log separator should be printed *before* **and** *after* the log line. Default: `False`
+
+### is_info_enabled
+
+```
+is_info_enabled(): bool
+```
+
+Whether info logging is enabled.
+
+### info
+
+```
+info(content: str, use_log_separator: bool): None
+```
+
+Prints info log.
+
+* `content (str)` - the content to be logged
+* `use_log_separator` - whether a log separator should be printed *before* **and** *after* the log line. Default: `False`
+
+### is_warning_enabled
+
+```
+is_warning_enabled(): bool
+```
+
+Whether warning logging is enabled.
+
+### warning
+
+```
+warning(content: str, force_warn: bool, use_log_separator: bool): None
+```
+
+Prints warning log.
+
+* `content (str)` - the content to be logged
+* `force_warn (bool)` - whether the warning log should be printed with the built-in `warn(msg)` function, otherwise `print(msg)` is used. Default: `True`
+* `use_log_separator` - whether a log separator should be printed *before* **and** *after* the log line. Default: `False`
+
+### is_error_enabled
+
+```
+is_error_enabled(): bool
+```
+
+Whether error logging is enabled.
+
+### error
+
+```
+error(content: str, force_fail: bool, use_log_separator: bool): None
+```
+
+Prints error log.
+
+* `content (str)` - the content to be logged
+* `force_fail (bool)` - whether the error log should be printed with the built-in `fail(msg)` function, otherwise `print(msg)` is used. Default: `True`
+* `use_log_separator` - whether a log separator should be printed *before* **and** *after* the log line. Default: `True`
+
+### log
+
+```
+log(log_level: str, content: str, force: bool, use_log_separator: bool): None
+```
+
+Prints a log.
+
+* `log_level (str)` - the log level, valid values are: `debug`, `info`, `warning` and `error`. If the value is not valid, the `print(msg)` function is used to print the `content`
+* `content (str)` - the content to be logged
+* `force (bool)` - whether the log should be printed with the built-in `warn(msg)` or `fail(msg)` function, depends on the `log_level` parameter value, otherwise `print(msg)` is used. Default: `False`
+* `use_log_separator` - whether a log separator should be printed *before* **and** *after* the log line. Default: `False`
+
+## Usage
+
+```
+load('ext://logger', 'logger')
+
+# automatically checks if debug log level is enabled
+logger.debug('My debug log')
+
+# automatically checks if info log level is enabled
+logger.info('My info log')
+
+# automatically checks if warning log level is enabled
+logger.warning('My warning log')
+
+# automatically checks if error log level is enabled
+logger.error('My error log')
+
+# consumes the "logger.info(...)" function under the hood
+logger.log('info', 'My info log')
+
+if logger.is_debug_enabled():
+	# do stuff...
+
+if logger.is_info_enabled():
+	# do stuff...
+
+if logger.is_warning_enabled():
+	# do stuff...
+
+if logger.is_error_enabled():
+	# do stuff...
+```

--- a/logger/Tiltfile
+++ b/logger/Tiltfile
@@ -1,0 +1,106 @@
+load('ext://color', 'color')
+
+_all_log_level = ['debug', 'info', 'warning', 'error']
+_info_allowed = ['info', 'warning', 'error']
+_warn_allowed = ['warning', 'error']
+_error_allowed = ['error']
+
+_log_level = 'info'
+_log_separator = '\n' + '*' * 20 + '\n'
+
+def _check_bool(value):
+	if not value:
+		return False
+	elif type(value) == 'bool':
+		return value
+	elif type(value) == 'string':
+		return value.lower() == 'true'
+	else:
+		return False
+
+def _is_log_level_enabled(log_level):
+	default_log_level = os.getenv('LOGGER_LOG_LEVEL', _log_level)
+	# validate default log level
+	if default_log_level not in _all_log_level:
+		fail(_build_message('Unknown log level: ' + default_log_level, True))
+	# debug default log level enables all other log levels
+	if default_log_level == 'debug' and log_level in _all_log_level:
+		return True
+	# info default log level enables info, warning and error log levels
+	elif default_log_level == 'info' and log_level in _info_allowed:
+		return True
+	# warning default log level enables warning and error log levels
+	elif default_log_level == 'warning' and log_level in _warn_allowed:
+		return True
+	# error default log level enables only error log level
+	elif default_log_level == 'error' and log_level in _error_allowed:
+		return True
+	else:
+		return False
+
+def _build_message(content, use_log_separator=False):
+	message = content
+	if _check_bool(os.getenv('LOGGER_USE_LOG_SEPARATOR', use_log_separator)):
+		log_separator = os.getenv('LOGGER_LOG_SEPARATOR', _log_separator)
+		message = log_separator + content + log_separator
+	return message
+
+def is_debug_enabled():
+	return _is_log_level_enabled('debug')
+
+def debug(content, use_log_separator=False):
+	if is_debug_enabled():
+		print(_build_message(color.magenta('[DEBUG] ') + content, use_log_separator))
+
+def is_info_enabled():
+	return _is_log_level_enabled('info')
+
+def info(content, use_log_separator=False):
+	if is_info_enabled():
+		print(_build_message(color.blue('[INFO] ') + content, use_log_separator))
+
+def is_warning_enabled():
+	return _is_log_level_enabled('warning')
+
+def warning(content, force_warn=True, use_log_separator=False):
+	if is_warning_enabled():
+		message = _build_message(color.yellow('[WARN] ') + content, use_log_separator)
+		if _check_bool(os.getenv('LOGGER_FORCE_WARN', force_warn)):
+			warn(message)
+		else:
+			print(message)
+
+def is_error_enabled():
+	return _is_log_level_enabled('error')
+
+def error(content, force_fail=True, use_log_separator=True):
+	if is_error_enabled():
+		message = _build_message(color.red('[ERROR] ') + content, use_log_separator)
+		if _check_bool(os.getenv('LOGGER_FORCE_FAIL', force_fail)):
+			fail(message)
+		else:
+			print(message)
+
+def log(log_level, content, force=False, use_log_separator=False):
+	if log_level == 'debug':
+		debug(content, use_log_separator)
+	elif log_level == 'info':
+		info(content, use_log_separator)
+	elif log_level == 'warning':
+		warning(content, force, use_log_separator)
+	elif log_level == 'error':
+		error(content, force, use_log_separator)
+	else:
+		print(content)
+
+logger = struct(
+	is_debug_enabled = is_debug_enabled,
+	debug = debug,
+	is_info_enabled = is_info_enabled,
+	info = info,
+	is_warning_enabled = is_warning_enabled,
+	warning = warning,
+	is_error_enabled = is_error_enabled,
+	error = error,
+	log = log
+)


### PR DESCRIPTION
For larger tilt projects with a lot of `print` function usages, it might be useful to have a more readable and colorful text output in the tilt ui. This approach makes things like debugging much easier. This logger is inspired by the [Maven](https://maven.apache.org/) logger.