### PR TITLE
Add show-readme extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`vault_client`](/vault_client): Reach secrets from a Vault instance.
 - [`wait_for_it`](/wait_for_it): Wait until command output is equal to given output.
 - [`base64`](/base64): Base64 encode or decode a string.
+- [`show-readme`](/show-readme): Use [mdv](https://github.com/axiros/terminal_markdown_viewer) to display a markdown file in the Tilt UI.
 
 ## Contribute an Extension
 

--- a/show-readme/README.md
+++ b/show-readme/README.md
@@ -1,0 +1,38 @@
+# Tilt Extension: Show README
+
+## Overview
+
+This Tilt extension adds a button to your Tilt resource that displays the contents of a specified markdown file (e.g., README.md) when clicked. It's a handy way to provide documentation, instructions, or any other information directly within the Tilt UI.
+
+## Features
+
+- Adds a button to Tilt resources.
+- Displays the content of a markdown file in a user-friendly format.
+- Customizable button text and icon.
+
+## Prerequisites
+
+To use this extension, you need to have the `mdv` pip package installed. `mdv` is a Markdown Viewer for the terminal.
+
+### Installing `mdv`
+
+You can install `mdv` using pip:
+
+```sh
+pip install mdv
+```
+
+## Example Tiltfile
+
+```python
+load('ext://show-readme', 'readme')
+
+readme(
+    name="my_readme_button",
+    resource="my_resource",
+    markdown_file_path="/path/to/README.md"
+)
+```
+
+## Author
+[Xinyu Kang](https://github.com/XinyuKang22)

--- a/show-readme/Tiltfile
+++ b/show-readme/Tiltfile
@@ -1,0 +1,37 @@
+load('ext://uibutton', 'cmd_button')
+
+def readme(name, resource, markdown_file_path, text='Show README', location='resource', icon_name='book'):
+    """
+    Adds a button to a Tilt resource that displays a README file when clicked.
+
+    Parameters:
+    - name (str): The unique name for the button.
+    - resource (str): The Tilt resource to which the button will be added.
+    - markdown_file_path (str): The file path of the markdown file to be displayed.
+    - text (str, optional): The text to be displayed on the button. Defaults to 'Show README'.
+    - location (str, optional): The location of the button on the Tilt resource. Defaults to 'resource'.
+    - icon_name (str, optional): The icon to be displayed on the button. Defaults to 'book'.
+
+    Returns:
+    - None
+
+    Example usage:
+    ```
+    readme(
+        name="my_readme_button",
+        resource="my_resource",
+        markdown_file_path="/path/to/README.md"
+    )
+    ```
+
+    This will add a button to the "my_resource" Tilt resource. When clicked, the button will display the 
+    contents of the specified README file. The button will have the text "Show README" and a "book" icon.
+    """
+    cmd_button(
+        name=name,
+        resource=resource,
+        argv=['mdv', markdown_file_path],
+        text=text,
+        location=location,
+        icon_name=icon_name
+    )

--- a/show-readme/Tiltfile
+++ b/show-readme/Tiltfile
@@ -1,8 +1,10 @@
 load('ext://uibutton', 'cmd_button')
 
-def readme(name, resource, markdown_file_path, text='Show README', location='resource', icon_name='book'):
+script_path = os.path.join(os.getcwd(), "show-readme.sh")
+
+def readme_in_html(name, resource, markdown_file_path, text='Show README', location='resource', icon_name='book'):
     """
-    Adds a button to a Tilt resource that displays a README file when clicked.
+    Adds a button to a Tilt resource that pops up a modal displaying the contents of a README file.
 
     Parameters:
     - name (str): The unique name for the button.
@@ -17,7 +19,7 @@ def readme(name, resource, markdown_file_path, text='Show README', location='res
 
     Example usage:
     ```
-    readme(
+    readme_in_html(
         name="my_readme_button",
         resource="my_resource",
         markdown_file_path="/path/to/README.md"
@@ -30,7 +32,43 @@ def readme(name, resource, markdown_file_path, text='Show README', location='res
     cmd_button(
         name=name,
         resource=resource,
-        argv=['mdv', markdown_file_path],
+        argv=[script_path, markdown_file_path],
+        text=text,
+        location=location,
+        icon_name=icon_name
+    )
+
+def readme_in_cmd(name, resource, markdown_file_path, text='Show README', location='resource', icon_name='book'):
+    """
+    Adds a button to a Tilt resource that pops up a modal displaying the contents of a README file.
+
+    Parameters:
+    - name (str): The unique name for the button.
+    - resource (str): The Tilt resource to which the button will be added.
+    - markdown_file_path (str): The file path of the markdown file to be displayed.
+    - text (str, optional): The text to be displayed on the button. Defaults to 'Show README'.
+    - location (str, optional): The location of the button on the Tilt resource. Defaults to 'resource'.
+    - icon_name (str, optional): The icon to be displayed on the button. Defaults to 'book'.
+
+    Returns:
+    - None
+
+    Example usage:
+    ```
+    readme_in_html(
+        name="my_readme_button",
+        resource="my_resource",
+        markdown_file_path="/path/to/README.md"
+    )
+    ```
+
+    This will add a button to the "my_resource" Tilt resource. When clicked, the button will display the 
+    contents of the specified README file. The button will have the text "Show README" and a "book" icon.
+    """
+    cmd_button(
+        name=name,
+        resource=resource,
+        argv=["mdv", markdown_file_path],
         text=text,
         location=location,
         icon_name=icon_name

--- a/show-readme/show-readme.sh
+++ b/show-readme/show-readme.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Define the file to store the port number
+PORT_FILE=".grip_port"
+
+# Function to find a free port
+find_free_port() {
+  local port
+  while true; do
+    port=$(shuf -i 2000-65000 -n 1)
+    # Check if the port is free
+    if ! ss -lpn | grep ":$port " > /dev/null; then
+      echo $port
+      return
+    fi
+  done
+}
+
+# Check if a port is provided as an argument
+if [ -n "$2" ]; then
+  PORT=$2
+  # Check if the provided port is free
+  if ss -lpn | grep ":$PORT " > /dev/null; then
+    echo "Provided port $PORT is already in use. Finding a free port instead."
+    PORT=$(find_free_port)
+  fi
+else
+  # Check if the port file exists and read the port from it
+  if [ -f "$PORT_FILE" ]; then
+    PORT=$(cat "$PORT_FILE")
+    # Check if the saved port is free
+    if ss -lpn | grep ":$PORT " > /dev/null; then
+      echo "Saved port $PORT is already in use. Finding a free port instead."
+      PORT=$(find_free_port)
+    fi
+  else
+    # Find a free port if none is provided and no port file exists
+    PORT=$(find_free_port)
+  fi
+fi
+
+# Save the port to the file
+echo $PORT > "$PORT_FILE"
+
+# Get the file to be served
+FILE=${1:-README.md}
+
+# Run the grip command with the found or provided port and specified file
+grip $FILE $PORT -b --quiet
+
+# Output the port number used
+echo "Grip is running on port $PORT"

--- a/show-readme/test/README.md
+++ b/show-readme/test/README.md
@@ -1,9 +1,0 @@
-# Welcome to My Project
-
-This project uses Tilt to manage Kubernetes resources.
-
-## Features
-
-- Feature 1
-- Feature 2
-- Feature 3

--- a/show-readme/test/README.md
+++ b/show-readme/test/README.md
@@ -1,0 +1,9 @@
+# Welcome to My Project
+
+This project uses Tilt to manage Kubernetes resources.
+
+## Features
+
+- Feature 1
+- Feature 2
+- Feature 3

--- a/show-readme/test/Tiltfile
+++ b/show-readme/test/Tiltfile
@@ -1,0 +1,9 @@
+load('../Tiltfile', 'readme')
+
+local_resource('hello', cmd='echo "Hello from resource"')
+
+readme(
+    name='render-readme',
+    markdown_file_path='./README.md',
+    resource='hello',
+)

--- a/show-readme/test/Tiltfile
+++ b/show-readme/test/Tiltfile
@@ -1,9 +1,35 @@
-load('../Tiltfile', 'readme')
+load('../Tiltfile', 'readme_in_html', 'readme_in_cmd')
 
-local_resource('hello', cmd='echo "Hello from resource"')
+k8s_yaml('frontend/deployment.yaml')
+k8s_resource('frontend')
 
-readme(
-    name='render-readme',
-    markdown_file_path='./README.md',
-    resource='hello',
+readme_in_html(
+    name='render-readme-frontend',
+    markdown_file_path='frontend/README.md',
+    resource='frontend',
+    text="README✨",
 )
+
+# readme_in_cmd(
+#     name='render-readme-frontend-cmd',
+#     markdown_file_path='frontend/README.md',
+#     resource='frontend',
+#     text="README🚀",
+# )
+
+k8s_yaml('backend/deployment.yaml')
+k8s_resource('backend')
+
+readme_in_html(
+    name='render-readme-backend',
+    markdown_file_path='backend/README.md',
+    resource='backend',
+    text="README✨",
+)
+
+# readme_in_cmd(
+#     name='render-readme-backend-cmd',
+#     markdown_file_path='backend/README.md',
+#     resource='backend',
+#     text="README🚀",
+# )

--- a/show-readme/test/backend/README.md
+++ b/show-readme/test/backend/README.md
@@ -1,0 +1,785 @@
+Grip -- GitHub Readme Instant Preview
+=====================================
+
+[![Current version on PyPI](http://img.shields.io/pypi/v/grip.svg)][pypi]
+[![Say Thanks!](https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg)](https://saythanks.io/to/joeyespo)
+
+Render local readme files before sending off to GitHub.
+
+Grip is a command-line server application written in Python that uses the
+[GitHub markdown API][markdown] to render a local readme file. The styles
+and rendering come directly from GitHub, so you'll know exactly how it will appear.
+Changes you make to the Readme will be instantly reflected in the browser without
+requiring a page refresh.
+
+
+Motivation
+----------
+
+Sometimes you just want to see the exact readme
+result before committing and pushing to GitHub.
+
+Especially when doing [Readme-driven development][rdd].
+
+
+Installation
+------------
+
+To install grip, simply:
+
+```console
+$ pip install grip
+```
+
+On OS X, you can also install with Homebrew:
+
+```console
+$ brew install grip
+```
+
+
+Usage
+-----
+
+To render the readme of a repository:
+
+```console
+$ cd myrepo
+$ grip
+ * Running on http://localhost:6419/
+```
+
+Now open a browser and visit [http://localhost:6419](http://localhost:6419/).
+Or run with `-b` and Grip will open a new browser tab for you.
+
+You can also specify a port:
+
+```console
+$ grip 80
+ * Running on http://localhost:80/
+```
+
+Or an explicit file:
+
+```console
+$ grip AUTHORS.md
+ * Running on http://localhost:6419/
+```
+
+Alternatively, you could just run `grip` and visit [localhost:6419/AUTHORS.md][AUTHORS.md]
+since grip supports relative URLs.
+
+You can combine the previous examples. Or specify a hostname instead of a port. Or provide both.
+
+```console
+$ grip AUTHORS.md 80
+ * Running on http://localhost:80/
+```
+
+```console
+$ grip CHANGES.md 0.0.0.0
+ * Running on http://0.0.0.0:6419/
+```
+
+```console
+$ grip . 0.0.0.0:80
+ * Running on http://0.0.0.0:80/
+```
+
+You can even bypass the server and **export** to a single HTML file, with all the styles and assets inlined:
+
+```console
+$ grip --export
+Exporting to README.html
+```
+
+Control the output name with the second argument:
+
+```console
+$ grip README.md --export index.html
+Exporting to index.html
+```
+
+If you're exporting a bunch of files, you can prevent styles from being inlining to save space with `--no-inline`:
+
+```console
+$ grip README.md --export --no-inline introduction.html
+Exporting to introduction.html
+```
+
+Reading and writing from **stdin** and **stdout** is also supported, allowing you to use Grip with other programs:
+
+```console
+$ cat README.md | grip -
+ * Running on http://localhost:6419/
+```
+
+```console
+$ grip AUTHORS.md --export - | bcat
+```
+
+```console
+$ cat README.md | grip --export - | less
+```
+
+This allows you to quickly test how things look by entering Markdown directly in your terminal:
+
+```console
+$ grip -
+Hello **world**!
+^D
+ * Running on http://localhost:6419/
+```
+
+*Note: `^D` means `Ctrl+D`, which works on Linux and OS X. On Windows you'll have to use `Ctrl+Z`.*
+
+Rendering as user-content like **comments** and **issues** is also supported, with an optional repository context for linking to issues:
+
+```console
+$ grip --user-content --context=joeyespo/grip
+ * Running on http://localhost:6419/
+```
+
+For more details and additional options, see the help:
+
+```console
+$ grip -h
+```
+
+
+Access
+------
+
+Grip strives to be as close to GitHub as possible. To accomplish this, grip
+uses [GitHub's Markdown API][markdown] so that changes to their rendering
+engine are reflected immediately without requiring you to upgrade grip.
+However, because of this you may hit the API's hourly rate limit. If this
+happens, grip offers a way to access the API using your credentials
+to unlock a much higher rate limit.
+
+```console
+$ grip --user <your-username> --pass <your-password>
+```
+
+Or use a [personal access token][] with an empty scope (note that a token is
+*required* if your GitHub account is set up with two-factor authentication):
+
+```console
+$ grip --pass <token>
+```
+
+You can persist these options [in your local configuration](#configuration).
+For security purposes, it's highly recommended that you **use an access token
+over a password**. (You could also keep your password safe by configuring
+Grip to [grab your password from a password manager][keychain-access].)
+
+There's also a [work-in-progress branch][offline-renderer] to provide
+**offline rendering**. Once this resembles GitHub more precisely, it'll
+be exposed in the CLI, and will ultimately be used as a seamless fallback
+engine for when the API can't be accessed.
+
+Grip always accesses GitHub over HTTPS,
+so your README and credentials are protected.
+
+
+Tips
+----
+
+Here's how others from the community are using Grip.
+
+Want to share your own? [Say hello @joeyespo][twitter] or [submit a pull request](#contributing).
+
+
+#### Create a local mirror of a Github Wiki
+
+```console
+$ git clone https://github.com/YOUR_USERNAME/YOUR_REPOSITORY.wiki.git
+$ cd YOUR_REPOSITORY.wiki
+$ grip
+```
+
+*By [Joshua Gourneau](https://twitter.com/gourneau/status/636329126643658753).*
+
+
+#### Generate HTML documentation from a collection of linked README files
+
+1. Enter the directory:
+
+   ```console
+   $ cd YOUR_DIR
+   $ export GRIPURL=$(pwd)
+   ```
+
+2. Include all assets by setting the `CACHE_DIRECTORY` [config variable](#configuration):
+
+   ```console
+   $ echo "CACHE_DIRECTORY = '$(pwd)/assets'" >> ~/.grip/settings.py
+   ```
+
+3. Export all your Markdown files with Grip and replace absolute asset paths with relative paths:
+
+   ```console
+   $ for f in *.md; do grip --export $f --no-inline; done
+   $ for f in *.html; do sed -i '' "s?$GRIPURL/??g" $f; done
+   ```
+
+You can optionally compress the set of HTML files to `docs.tgz` with:
+
+   ```console
+   $ tar -czvf docs.tgz `ls | grep [\.]html$` assets
+   ```
+
+Looking for a cross platform solution? Here's an equivalent [Python script](https://gist.github.com/mrexmelle/659abc02ae1295d60647).
+
+*By [Matthew R. Tanudjaja](https://github.com/mrexmelle).*
+
+
+Configuration
+-------------
+
+To customize Grip, create `~/.grip/settings.py`, then add one or more of the following variables:
+
+- `HOST`: The host to use when not provided as a CLI argument, `localhost` by default
+- `PORT`: The port to use when not provided as a CLI argument, `6419` by default
+- `DEBUG`: Whether to use Flask's debugger when an error happens, `False` by default
+- `DEBUG_GRIP`: Prints extended information when an error happens, `False` by default
+- `API_URL`: Base URL for the github API, for example that of a Github Enterprise instance. `https://api.github.com` by default
+- `CACHE_DIRECTORY`: The directory, relative to `~/.grip`, to place cached assets (this gets run through the following filter: `CACHE_DIRECTORY.format(version=__version__)`), `'cache-{version}'` by default
+- `AUTOREFRESH`: Whether to automatically refresh the Readme content when the file changes, `True` by default
+- `QUIET`: Do not print extended information, `False` by default
+- `STYLE_URLS`: Additional URLs that will be added to the rendered page, `[]` by default
+- `USERNAME`: The username to use when not provided as a CLI argument, `None` by default
+- `PASSWORD`: The password or [personal access token][] to use when not provided as a CLI argument (*Please don't save your passwords here.* Instead, use an access token or drop in this code [grab your password from a password manager][keychain-access]), `None` by default
+
+Note that this is a Python file. If you see `'X' is not defined` errors, you
+may have overlooked some quotes. For example:
+
+```py
+USERNAME = 'your-username'
+PASSWORD = 'your-personal-access-token'
+```
+
+
+#### Environment variables
+
+- `GRIPHOME`: Specify an alternative `settings.py` location, `~/.grip` by default
+- `GRIPURL`: The URL of the Grip server, `/__/grip` by default
+
+#### Advanced
+
+This file is a normal Python script, so you can add more advanced configuration.
+
+For example, to read a setting from the environment and provide a default value
+when it's not set:
+
+```python
+PORT = os.environ.get('GRIP_PORT', 8080)
+```
+
+
+API
+---
+
+You can access the API directly with Python, using it in your own projects:
+
+```python
+from grip import serve
+
+serve(port=8080)
+ * Running on http://localhost:8080/
+```
+
+Run main directly:
+
+```python
+from grip import main
+
+main(argv=['-b', '8080'])
+ * Running on http://localhost:8080/
+```
+
+Or access the underlying Flask application for even more flexibility:
+
+```python
+from grip import create_app
+
+grip_app = create_app(user_content=True)
+# Use in your own app
+```
+
+
+### Documentation
+
+#### serve
+
+Runs a local server and renders the Readme file located
+at `path` when visited in the browser.
+
+```python
+serve(path=None, host=None, port=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, autorefresh=True, browser=False, grip_class=None)
+```
+
+- `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
+- `host`: The host to listen on, defaulting to the HOST configuration variable
+- `port`: The port to listen on, defaulting to the PORT configuration variable
+- `user_content`: Whether to render a document as [user-content][] like user comments or issues
+- `context`: The project context to use when `user_content` is true, which
+             takes the form of `username/project`
+- `username`: The user to authenticate with GitHub to extend the API limit
+- `password`: The password to authenticate with GitHub to extend the API limit
+- `render_offline`: Whether to render locally using [Python-Markdown][] (Note: this is a work in progress)
+- `render_wide`: Whether to render a wide page, `False` by default (this has no effect when used with `user_content`)
+- `render_inline`: Whether to inline the styles within the HTML file
+- `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
+- `title`: The page title, derived from `path` by default
+- `autorefresh`: Automatically update the rendered content when the Readme file changes, `True` by default
+- `browser`: Open a tab in the browser after the server starts., `False` by default
+- `grip_class`: Use a custom [Grip class](#class-gripflask)
+
+
+#### export
+
+Writes the specified Readme file to an HTML file with styles and assets inlined.
+
+```python
+export(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=True, out_filename=None, api_url=None, title=None, quiet=None, theme='light', grip_class=None)
+```
+
+- `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
+- `user_content`: Whether to render a document as [user-content][] like user comments or issues
+- `context`: The project context to use when `user_content` is true, which
+             takes the form of `username/project`
+- `username`: The user to authenticate with GitHub to extend the API limit
+- `password`: The password to authenticate with GitHub to extend the API limit
+- `render_offline`: Whether to render locally using [Python-Markdown][] (Note: this is a work in progress)
+- `render_wide`: Whether to render a wide page, `False` by default (this has no effect when used with `user_content`)
+- `render_inline`: Whether to inline the styles within the HTML file (Note: unlike the other API functions, this defaults to `True`)
+- `out_filename`: The filename to write to, `<in_filename>.html` by default
+- `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
+- `title`: The page title, derived from `path` by default
+- `quiet`: Do not print to the terminal
+- `theme`: Theme to view markdown file (light mode or dark mode). Valid options ("light", "dark"). Default: "light".
+- `grip_class`: Use a custom [Grip class](#class-gripflask)
+
+
+#### create_app
+
+Creates a Flask application you can use to render and serve the Readme files.
+This is the same app used by `serve` and `export` and initializes the cache,
+using the cached styles when available.
+
+```python
+create_app(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, text=None, grip_class=None)
+```
+
+- `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
+- `user_content`: Whether to render a document as [user-content][] like user comments or issues
+- `context`: The project context to use when `user_content` is true, which
+             takes the form of `username/project`
+- `username`: The user to authenticate with GitHub to extend the API limit
+- `password`: The password to authenticate with GitHub to extend the API limit
+- `render_offline`: Whether to render locally using [Python-Markdown][] (Note: this is a work in progress)
+- `render_wide`: Whether to render a wide page, `False` by default (this has no effect when used with `user_content`)
+- `render_inline`: Whether to inline the styles within the HTML file
+- `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
+- `title`: The page title, derived from `path` by default
+- `text`: A string or stream of Markdown text to render instead of being loaded from `path` (Note: `path` can be used to set the page title)
+- `grip_class`: Use a custom [Grip class](#class-gripflask)
+
+
+#### render_app
+
+Renders the application created by `create_app` and returns the HTML that would
+normally appear when visiting that route.
+
+```python
+render_app(app, route='/')
+```
+
+- `app`: The Flask application to render
+- `route`: The route to render, '/' by default
+
+
+#### render_content
+
+Renders the specified markdown text without caching.
+
+```python
+render_content(text, user_content=False, context=None, username=None, password=None, render_offline=False, api_url=None, title=None)
+```
+
+- `text`: The Markdown text to render
+- `user_content`: Whether to render a document as [user-content][] like user comments or issues
+- `context`: The project context to use when `user_content` is true, which
+             takes the form of `username/project`
+- `username`: The user to authenticate with GitHub to extend the API limit
+- `password`: The password to authenticate with GitHub to extend the API limit
+- `render_offline`: Whether to render locally using [Python-Markdown][] (Note: this is a work in progress)
+- `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. This is required when not using the offline renderer.
+- `title`: The page title, derived from `path` by default
+
+
+#### render_page
+
+Renders the markdown from the specified path or text, without caching,
+and returns an HTML page that resembles the GitHub Readme view.
+
+```python
+render_page(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, text=None, quiet=None, theme='light', grip_class=None)
+```
+
+- `path`: The path to use for the page title, rendering `'README.md'` if None
+- `user_content`: Whether to render a document as [user-content][] like user comments or issues
+- `context`: The project context to use when `user_content` is true, which
+             takes the form of `username/project`
+- `username`: The user to authenticate with GitHub to extend the API limit
+- `password`: The password to authenticate with GitHub to extend the API limit
+- `render_offline`: Whether to render offline using [Python-Markdown][] (Note: this is a work in progress)
+- `render_wide`: Whether to render a wide page, `False` by default (this has no effect when used with `user_content`)
+- `render_inline`: Whether to inline the styles within the HTML file
+- `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
+- `title`: The page title, derived from `path` by default
+- `text`: A string or stream of Markdown text to render instead of being loaded from `path` (Note: `path` can be used to set the page title)
+- `quiet`: Do not print to the terminal
+- `theme`: Theme to view markdown file (light mode or dark mode). Valid options ("light", "dark"). Default: "light".
+- `grip_class`: Use a custom [Grip class](#class-gripflask)
+
+
+#### clear_cache
+
+Clears the cached styles and assets.
+
+```python
+clear_cache(grip_class=None)
+```
+
+#### main
+
+Runs Grip with the specified arguments.
+
+```python
+main(argv=None, force_utf8=True)
+```
+
+- `argv`: The arguments to run with, `sys.argv[1:]` by default
+- `force_utf8`: Sets the default encoding to `utf-8` in the current Python instance. This has no effect on Python 3 since Unicode is handled by default
+
+
+### Classes
+
+#### class Grip(Flask)
+
+A Flask application that can serve a file or directory containing a README.
+
+```python
+Grip(source=None, auth=None, renderer=None, assets=None, render_wide=None, render_inline=None, title=None, autorefresh=None, quiet=None, theme='light', grip_url=None, static_url_path=None, instance_path=None, **kwargs)
+```
+
+##### default_renderer
+
+Returns the default renderer using the current config. This is only used if
+renderer is set to None in the constructor.
+
+```python
+Grip.default_renderer()
+```
+
+##### default_asset_manager
+
+Returns the default asset manager using the current config. This is only used
+if asset_manager is set to None in the constructor.
+
+```python
+Grip.default_asset_manager()
+```
+
+##### add_content_types
+
+Adds the application/x-font-woff and application/octet-stream content types if
+they are missing. Override to add additional content types on initialization.
+
+```python
+Grip.add_content_types()
+```
+
+##### clear_cache
+
+Clears the downloaded assets.
+
+```python
+Grip.clear_cache()
+```
+
+##### render
+
+Renders the application and returns the HTML unicode that would normally appear
+when visiting in the browser.
+
+```python
+Grip.render(route=None)
+```
+
+- `route`: The route to render, `/` by default
+
+##### run
+
+Starts a server to render the README. This calls [Flask.run][] internally.
+
+```python
+Grip.run(host=None, port=None, debug=None, use_reloader=None, open_browser=False)
+```
+
+- `host`: The hostname to listen on. Set this to `'0.0.0.0'` to have the server
+          available externally as well, `'localhost'` by default
+- `port`: The port of the webserver. Defaults to `6419`
+- `debug`: If given, enable or disable debug mode. See [Flask.debug][].
+- `use_reloader`: Should the server automatically restart the python process
+                  if modules were changed? `False` by default unless the
+                  `DEBUG_GRIP` setting is specified.
+- `open_browser`: Opens the browser to the address when the server starts
+
+
+#### class AlreadyRunningError(RuntimeError)
+
+Raised when `Grip.run` is called while the server is already running.
+
+```python
+AlreadyRunningError()
+```
+
+
+#### class ReadmeNotFoundError(NotFoundError or IOError)
+
+Raised when the specified Readme could not be found.
+
+```python
+ReadmeNotFoundError(path=None, message=None)
+```
+
+
+#### class ReadmeAssetManager(object)
+
+Manages the style and font assets rendered with Readme pages. This is an
+abstract base class.
+
+```python
+ReadmeAssetManager(cache_path, style_urls=None)
+```
+
+
+#### class GitHubAssetManager(ReadmeAssetManager)
+
+Manages the style and font assets rendered with Readme pages. Set cache_path to
+None to disable caching.
+
+
+#### class ReadmeReader(object)
+
+Reads Readme content from a URL subpath. This is an abstract base class.
+
+```python
+ReadmeReader()
+```
+
+
+#### class DirectoryReader(ReadmeReader)
+
+Reads Readme files from URL subpaths.
+
+```python
+DirectoryReader(path=None, silent=False)
+```
+
+
+#### class TextReader(ReadmeReader)
+
+Reads Readme content from the provided unicode string.
+
+```python
+TextReader(text, display_filename=None)
+```
+
+
+#### class StdinReader(TextReader)
+
+Reads Readme text from STDIN.
+
+```python
+StdinReader(display_filename=None)
+```
+
+
+#### class ReadmeRenderer(object)
+
+Renders the Readme. This is an abstract base class.
+
+```python
+ReadmeRenderer(user_content=None, context=None)
+```
+
+
+#### class GitHubRenderer(ReadmeRenderer)
+
+Renders the specified Readme using the GitHub Markdown API.
+
+```python
+GitHubRenderer(user_content=None, context=None, api_url=None, raw=None)
+```
+
+
+#### class OfflineRenderer(ReadmeRenderer)
+
+Renders the specified Readme locally using pure Python. Note: This is currently
+an incomplete feature.
+
+```python
+OfflineRenderer(user_content=None, context=None)
+```
+
+
+### Constants
+
+
+#### SUPPORTED_TITLES
+
+The common Markdown file titles on GitHub.
+
+```python
+SUPPORTED_TITLES = ['README', 'Home']
+```
+
+- `filename`: The UTF-8 file to read.
+
+
+#### SUPPORTED_EXTENSIONS
+
+The supported extensions, as defined by [GitHub][markdown].
+
+```python
+SUPPORTED_EXTENSIONS = ['.md', '.markdown']
+```
+
+
+#### DEFAULT_FILENAMES
+
+This constant contains the names Grip looks for when no file is provided.
+
+```python
+DEFAULT_FILENAMES = [title + ext
+                     for title in SUPPORTED_TITLES
+                     for ext in SUPPORTED_EXTENSIONS]
+```
+
+
+#### DEFAULT_FILENAME
+
+This constant contains the default Readme filename, namely:
+
+```python
+DEFAULT_FILENAME = DEFAULT_FILENAMES[0]  # README.md
+```
+
+
+#### DEFAULT_GRIPHOME
+
+This constant points to the default value if the `GRIPHOME`
+[environment variable](#environment-variables) is not specified.
+
+```python
+DEFAULT_GRIPHOME = '~/.grip'
+```
+
+
+#### DEFAULT_GRIPURL
+
+The default URL of the Grip server and all its assets:
+
+```python
+DEFAULT_GRIPURL = '/__/grip'
+```
+
+
+#### DEFAULT_API_URL
+
+The default app_url value:
+
+```python
+DEFAULT_API_URL = 'https://api.github.com'
+```
+
+
+Testing
+-------
+
+Install the package and test requirements:
+
+```console
+$ pip install -e .[tests]
+```
+
+Run tests with [pytest][]:
+
+```console
+$ pytest
+```
+
+Or to re-run tests as you make changes, use [pytest-watch][]:
+
+```console
+$ ptw
+```
+
+
+#### External assumption tests
+
+If you're experiencing a problem with Grip, it's likely that an assumption made
+about the GitHub API has been broken. To verify this, run:
+
+```console
+$ pytest -m assumption
+```
+
+Since the external assumptions rely on an internet connection, you may want to skip
+them when developing locally. Tighten the cycle even further by stopping on the
+first failure with `-x`:
+
+```console
+$ pytest -xm "not assumption"
+```
+
+Or with [pytest-watch][]:
+
+```console
+$ ptw -- -xm "not assumption"
+```
+
+
+Contributing
+------------
+
+1. Check the open issues or open a new issue to start a discussion around
+   your feature idea or the bug you found
+2. Fork the repository and make your changes
+3. Open a new pull request
+
+If your PR has been waiting a while, feel free to [ping me on Twitter][twitter].
+
+Use this software often? <a href="https://saythanks.io/to/joeyespo" target="_blank"><img src="https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg" align="center" alt="Say Thanks!"></a>
+:smiley:
+
+
+[pypi]: http://pypi.python.org/pypi/grip/
+[markdown]: http://developer.github.com/v3/markdown
+[rdd]: http://tom.preston-werner.com/2010/08/23/readme-driven-development.html
+[authors.md]: AUTHORS.md
+[offline-renderer]: http://github.com/joeyespo/grip/tree/offline-renderer
+[personal access token]: https://github.com/settings/tokens/new?scopes=
+[keychain-access]: https://gist.github.com/klmr/3840aa3c12f947e4064c
+[task-lists]: https://github.com/blog/1825-task-lists-in-all-markdown-documents
+[user-content]: http://github.github.com/github-flavored-markdown
+[python-markdown]: http://github.com/waylan/Python-Markdown
+[flask.run]: http://flask.pocoo.org/docs/0.10/api/#flask.Flask.run
+[flask.debug]: http://flask.pocoo.org/docs/0.10/api/#flask.Flask.debug
+[pytest]: http://pytest.org/
+[pytest-watch]: https://github.com/joeyespo/pytest-watch
+[twitter]: http://twitter.com/joeyespo

--- a/show-readme/test/backend/deployment.yaml
+++ b/show-readme/test/backend/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: b
+  name: frontend
 spec:
   containers:
     - name: b

--- a/show-readme/test/frontend/README.md
+++ b/show-readme/test/frontend/README.md
@@ -1,0 +1,357 @@
+# Zircon - A user-friendly Tile Engine & Text GUI [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Do%20you%20plan%20to%20make%20a%20roguelike%3F%20Look%20no%20further.%20Zircon%20is%20the%20right%20tool%20for%20the%20job.&url=https://github.com/Hexworks/zircon&hashtags=games,roguelikes)
+
+<img src="https://cdn.discordapp.com/attachments/205245036084985857/481213000540225550/full_example.gif"  alt="Full Example"/>
+
+Need info? Check the [Docs][zircon-docs]
+| or [Create an issue](https://github.com/Hexworks/zircon/issues/new)
+| Check [our project Board](https://github.com/Hexworks/zircon/projects/2)
+| [Ask us on Discord][discord]
+| Support us on [Patreon](https://www.patreon.com/hexworks)
+| [Javadoc / Kdoc](https://hexworks.github.io/zircon/)
+
+[![Circle CI](https://circleci.com/gh/Hexworks/zircon/tree/master.svg?style=shield)](https://circleci.com/gh/Hexworks/zircon/)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.hexworks.zircon/zircon.core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.hexworks.zircon/zircon.core)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+
+---
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+    - [Adding Zircon as a Maven Dependency](#adding-zircon-as-a-maven-dependency)
+    - [Basic Usage](#basic-usage)
+- [Best Practices](#best-practices)
+- [Features at a Glance](#features-at-a-glance)
+    - [Drawing](#drawing)
+    - [Input Handling](#input-handling)
+    - [Layering](#layering)
+    - [Text GUI Components](#text-gui-components)
+    - [Animations](#animations)
+    - [Shape and Box Drawing](#shape-and-box-drawing)
+    - [Fonts and Tilesets](#fonts-and-tilesets)
+    - [Road Map](#road-map)
+    - [License](#license)
+    - [Credits](#credits)
+    - [Thanks](#thanks)
+
+## Getting Started
+
+If you want to start working with Zircon you can either add it to your project as a Maven dependency or you can try out
+the skeleton projects
+([Java](https://github.com/Hexworks/zircon.skeleton.java), [Kotlin](https://github.com/Hexworks/zircon.skeleton.kotlin))
+which come with batteries included.
+
+The official [documentation site][zircon-docs] contains a lot of information. The examples are also documented on the
+[Zircon Examples](https://hexworks.org/zircon/examples/) page *(under construction)*, and the best place to start is the
+[Zircon Crash Course](https://hexworks.org/zircon/docs/2018-07-18-a-zircon-crash-course).
+
+If you like learning by doing check out the source of *Zircon* from [here](https://github.com/Hexworks/zircon) and you
+can run the examples for yourself. If you are using *Java*
+start [here](https://github.com/Hexworks/zircon/tree/master/zircon.jvm.examples/src/main/java/org/hexworks/zircon/examples)
+. Alternatively if you use *Kotlin* the code can be
+found [here](https://github.com/Hexworks/zircon/tree/master/zircon.jvm.examples/src/main/kotlin/org/hexworks/zircon).
+
+If you just want to peruse the *Zircon* API navigate [here][api]. Everything which is intended to be part of the public
+API is there.
+
+You can find the *Javadoc* / *Kdoc* [here](https://hexworks.github.io/zircon/)
+
+If you'd like to talk to us, join us on our [Discord Server][discord].
+
+### Adding Zircon as a Maven Dependency
+
+Maven:
+
+```xml
+
+<dependencies>
+    <dependency>
+        <groupId>org.hexworks.zircon</groupId>
+        <artifactId>zircon.core-jvm</artifactId>
+        <version>2021.1.0-RELEASE</version>
+    </dependency>
+    <!-- use zircon.jvm.libgdx if you want to use LibGDX instead of Swing -->
+    <dependency>
+        <groupId>org.hexworks.zircon</groupId>
+        <artifactId>zircon.jvm.swing</artifactId>
+        <version>2021.1.0-RELEASE</version>
+    </dependency>
+</dependencies>
+```
+
+Gradle:
+
+```groovy
+dependencies {
+    implementation "org.hexworks.zircon:zircon.core-jvm:2021.1.0-RELEASE"
+    implementation "org.hexworks.zircon:zircon.jvm.swing:2021.1.0-RELEASE"
+}
+```
+
+### Basic Usage
+
+Once you have the dependencies set up you can start using *Zircon* by creating a `TileGrid`:
+
+```java
+public class Main {
+
+    public static void main(String[] args) {
+
+        // a TileGrid represents a 2D grid composed of Tiles
+        TileGrid tileGrid = SwingApplications.startTileGrid(
+                AppConfig.newBuilder()
+                        // The number of tiles horizontally, and vertically
+                        .withSize(60, 30)
+                        // You can choose from a wide array of CP437, True Type or Graphical tilesets
+                        // that are built into Zircon
+                        .withDefaultTileset(CP437TilesetResources.rexPaint16x16())
+                        .build());
+
+        // A Screen is an abstraction that lets you use text GUI Components
+        // You can have multiple Screens attached to the same TileGrid to be able to create multiple
+        // screens for your app.
+        Screen screen = Screen.create(tileGrid);
+
+        // Creating text GUI Components is super simple
+        Label label = Components.label()
+                .withText("Hello, Zircon!")
+                .withAlignment(ComponentAlignments.alignmentWithin(tileGrid, ComponentAlignment.CENTER))
+                .build();
+
+        // Screens can hold GUI components
+        screen.addComponent(label);
+
+        // Displaying a screen will make it visible. It will also hide a previously shown Screen.
+        screen.display();
+
+        // Zircon comes with a plethora of built-in color themes
+        screen.setTheme(ColorThemes.arc());
+    }
+}
+```
+
+The output of this example is:
+
+![Zircon Application](images/hello_zircon.png)
+
+*Congratulations!* Now you are a *Zircon* user.
+
+## Best Practices
+
+The following are some guidelines that can help you if you get *stuck*:
+
+If you want to build something (a `TileGraphics`, a `Component` or anything that is part of the public API) it is
+almost sure that there is a `Builder` or a factory object for it. Each type that has a builder will have a
+`newBuilder` function you can call to create the corresponding builder: `Tile.newBuilder()`.
+
+If there are multiple classes of objects that can be created there might also be a utility class, 
+like `Shapes` to create different `Shape` objects. Your IDE will help you with this.
+
+These classes reside in the `org.hexworks.zircon.api` package. There are some classes that are grouped together into a
+single utility class, however. With `Components` for example, you can obtain `Builder`s for all `Component`s
+like `Components.panel()` or `Components.checkBox()`. Likewise, you can use `DrawSurfaces` to obtain builders
+for `TileGraphics` and `TileImage`.
+
+If you want to work with external files like tilesets or REXPaint files check the same  package
+(`org.hexworks.zircon.api`), and look for classes that end with `*Resources`. There are a bunch of built-in tilesets
+for example which you can choose from, but you can also load your own.
+
+The rule of thumb is that if you need something external there is probably a `*Resources` class for it (like
+the `CP437TilesetResources`).
+
+You can use *anything* you can find in the [API][api] package, they are part of the public API, and safe to use.
+The [internal][internal] package however is considered private to *Zircon* so keep in mind that they can change any
+time.
+
+Some topics are explained in depth in the [documentation][zircon-docs].
+
+If you want to see some example code take a look at the examples project [here][examples]. Most examples have
+identical *Java* and *Kotlin* variants.
+
+If all else fails read the javadocs. API classes are well documented.
+
+If you have any problems that are not answered here feel free to ask us at the [Hexworks Discord server][discord].
+
+## Features at a Glance
+
+### Drawing
+
+> You can find detailed documentation about drawing [here][drawing-docs].
+
+The most basic operation *Zircon* supports is `draw`ing. You can draw individual `Tile`s or `TileGraphics` objects on
+your `TileGrid`. a `TileGraphics` object is composed of `Tile`s. This is a powerful tool, and you can implement more
+complex features using simple `draw` operations. In fact the component system is implemented on top of drawing, layering
+and input handling features.
+
+If you use REXPaint to design your programs, the good news is that you can import your `.xp` files as well. Read more
+about it [here](https://hexworks.org/zircon/docs/2018-11-22-resource-handling#rexpaint-files).
+
+You can also use `Modifier`s in your `Tile`s such as `blink`, `verticalFlip` or `glow`. For a full list, check
+[this](https://github.com/Hexworks/zircon/blob/master/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/Modifiers.kt)
+factory object.
+`Modifier`s can either change the texture (like the ones above) or the `Tile` itself:
+
+![Modifiers](images/gifs/modifiers.gif)
+
+### Input handling
+
+> Read about input handling in the docs [here][input-docs].
+
+Both the `TileGrid` and the `Screen` interfaces implement `UIEventSource` which means that you can listen for user
+inputs using them. This includes *keystrokes* and *mouse input* as well.
+
+### Layering
+
+> Layering is detailed [here][layer-docs]. For a primer on `Screen`s go [here][screen-docs].
+
+Both the `TileGrid` and the `Screen` interfaces implement `Layerable` which means that you can add `Layer`s on top of
+them. Every `Layerable` can have an arbitrary amount of `Layer`s. `Layer`s are like `TileGraphics` objects, and you can
+also have transparency in them which can be used to create fancy effects.
+`Component`s are also `Layer`s themselves. Take a look:
+
+![Layers](images/layers.png)
+
+### Text GUI Components
+
+> You can read more about the Component System on the [documentation page][component-docs].
+> Color themes are detailed [here][color-theme-docs].
+
+`Component`s are GUI controls which can be used for showing content to the user (`Label`s, `Paragraph`s, etc.), enabling
+them to interact with your program (`Button`s, `Slider`s, etc.) or to hold other components (`Panel`s for example).
+
+These components are rather simple, and you can expect them to work in a way you might be familiar with:
+
+- You can click on them (press and release are different events).
+- You can attach event listeners on them.
+- Zircon implements focus handling, so you can navigate between the components using the `[Tab]` key
+  (forwards) or the `[Shift]+[Tab]` keystroke (backwards).
+- Components can be hovered, and you can also apply color themes to them.
+
+What's more is that you can apply `ColorTheme`s to `Component`s. There are a bunch of built-in themes, and you can also
+create your own.
+
+To see a full list of available `Component`s take a look at the
+[Components](https://github.com/Hexworks/zircon/blob/master/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/Components.kt)
+factory object or navigate to the [component docs page][component-docs].
+
+This is an example of how components look in action:
+
+![All Components](images/gifs/all_components.gif)
+
+### Animations:
+
+> Read more about Animations in the [docs][animation-docs].
+
+Animations are supported out of the box. You can either create them programmatically, or statically using *Zircon's* own
+animation format: `.zap` (Zircon Animation Package). More about that [here][animation-docs]. This is how an animation
+looks like:
+
+![Animation Example](images/gifs/hexworks_skull.gif)
+
+### Shape and box drawing
+
+> The shape documentation page can be found [here][shape-docs].
+
+You can draw `Shape`s like rectangles and triangles by using one of the `ShapeFactory` implementations. What's supported
+out of the box is
+*triangle*, *rectangle* and *line*. The former two have filled versions as well. Check out the `Shapes` factory object
+[here](https://github.com/Hexworks/zircon/blob/efa5b6f317eda9c22834140588dcbdd47fb4a3ab/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/Shapes.kt)
+.
+
+### Fonts and Tilesets
+
+> The documentation page for tilesets is [here][tileset-docs].
+
+Zircon comes with a bunch of built-in fonts tilesets. These come in 3 flavors:
+
+- CP437 tilesets *(More on using them 
+  [here](https://hexworks.org/zircon/docs/2018-11-22-resource-handling#cp437-tilesets))*
+- True Type Fonts
+- and Graphical tilesets *(Usage info
+  [here](https://hexworks.org/zircon/docs/2018-11-22-resource-handling#graphical-tilesets))*
+
+Zircon also comes with its own tileset format (`ztf`: Zircon Tileset Format) which is **very easy to use**. It is
+detailed [here](https://hexworks.org/zircon/docs/2018-11-22-resource-handling#the-zircon-tileset-format).
+
+## Road Map
+
+If you want to see a new feature feel free to [create a new Issue](https://github.com/Hexworks/zircon/issues/new) or
+discuss it with us on [Discord][discord]. Here are some features which are either under way or planned:
+
+- [x] [Scrollable Components](https://github.com/Hexworks/zircon/issues/25)
+- [x] [Menus](https://github.com/Hexworks/zircon/issues/135)
+- [x] [Table Component](https://github.com/Hexworks/zircon/issues/185)
+- [x] [Javadoc-style Documentation](https://github.com/Hexworks/zircon/issues/146)
+- [x] [Grid / Screen Filters](https://github.com/Hexworks/zircon/issues/271)
+- [ ] [Floating Components](https://github.com/Hexworks/zircon/issues/23)
+- [ ] [Drag'n Drop Support](https://github.com/Hexworks/zircon/issues/22)
+- [ ] [Custom Layout Support](https://github.com/Hexworks/zircon/issues/28)
+- [ ] [Component Themes](https://github.com/Hexworks/zircon/issues/29)
+- [ ] [Custom Component Support](https://github.com/Hexworks/zircon/issues/26)
+- [ ] [Tree Component](https://github.com/Hexworks/zircon/issues/184)
+- [ ] [Accordion Component](https://github.com/Hexworks/zircon/issues/27)
+- [ ] [Combo Box Component](https://github.com/Hexworks/zircon/issues/262)
+- [ ] [IntelliJ Plugin](https://github.com/Hexworks/zircon/issues/191)
+- [ ] [Console for Zircon](https://github.com/Hexworks/zircon/issues/183)
+
+If you'd like to give any of these a shot feel free to *contribute*.
+
+## License
+
+Zircon is made available under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
+
+## Credits
+
+Zircon is created and maintained by Addamsson, Coldwarrl, G3ldrin, Milonoir, Seveen and many others.
+
+*We're open to suggestions, feel free to message us on [Discord][discord] or open an issue.*
+*Pull requests are also welcome!*
+
+Zircon is powered by:
+
+<a href="https://www.jetbrains.com/idea/">
+    <img src="https://github.com/Hexworks/zircon/blob/master/images/idea_logo.png" width="40" height="40"  alt="IDEA"/>
+</a>
+<a href="https://kotlinlang.org/">
+    <img src="https://github.com/Hexworks/zircon/blob/master/images/kotlin_logo.png" width="40" height="40"  alt="Kotlin"/>
+</a>
+<a href="https://www.yourkit.com/java/profiler/">
+    <img src="https://github.com/Hexworks/zircon/blob/master/images/yklogo.png" width="168" height="40"  alt="Yourkit"/>
+</a>
+
+## Thanks
+
+Thanks to the folks over at [Dwarf Fortress Tileset Repository](http://dwarffortresswiki.org/Tileset_repository) for
+letting us bundle their tilesets.
+
+Thanks to *Kyzrati* who let us bundle the [REXPaint Tilesets](https://www.gridsagegames.com/rexpaint/) into Zircon!
+
+Zircon comes bundled with the [Nethack Tileset](https://nethackwiki.com/wiki/Tileset).
+
+Some True Type fonts are used from [Google Fonts](https://fonts.google.com/).
+
+Thanks to *VileR* for the [Oldschool Font Pack](https://int10h.org/oldschool-pc-fonts/) which we bundled into Zircon.
+
+
+[discord]:https://discord.gg/vSNgvBh
+[zircon-version]:2021.1.0-RELEASE
+[examples]:https://github.com/Hexworks/zircon/tree/master/zircon.jvm.examples/src/main
+[api]:https://github.com/Hexworks/zircon/tree/master/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api
+[internal]:https://github.com/Hexworks/zircon/tree/master/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/internal
+[resource]:https://github.com/Hexworks/zircon/tree/master/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/resource
+[zircon-docs]:https://hexworks.org/zircon/docs/
+[animation-docs]:https://hexworks.org/zircon/docs/2019-04-26-animation-support
+[color-theme-docs]:https://hexworks.org/zircon/docs/2018-11-20-working-with-color-themes
+[component-docs]:https://hexworks.org/zircon/docs/2018-11-15-the-component-system
+[crash-course]:https://hexworks.org/zircon/docs/2018-07-18-a-zircon-crash-course
+[design-docs]:https://hexworks.org/zircon/docs/2018-11-20-the-design-philosophy-behind-zircon
+[input-docs]:https://hexworks.org/zircon/docs/2018-11-21-input-handling
+[layer-docs]:https://hexworks.org/zircon/docs/2018-11-21-how-layers-work
+[logging-docs]:https://hexworks.org/zircon/docs/2019-03-27-logging
+[release-docs]:https://hexworks.org/zircon/docs/2019-01-11-release-process-and-versioning-scheme
+[screen-docs]:https://hexworks.org/zircon/docs/2018-08-18-a-primer-on-screens
+[shape-docs]:https://hexworks.org/zircon/docs/2018-11-21-shapes
+[drawing-docs]:https://hexworks.org/zircon/docs/2018-11-19-how-to-work-with-tile-graphics
+[tileset-docs]:https://hexworks.org/zircon/docs/2018-11-22-resource-handling
+

--- a/show-readme/test/frontend/deployment.yaml
+++ b/show-readme/test/frontend/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: a
+  name: backend
 spec:
   containers:
     - name: a


### PR DESCRIPTION
Introduces a new Tilt extension that adds a button to a specified Tilt resource to display the contents of a markdown file, such as README.md.