### PR TITLE
helm_resource: kubectl_cmd should define `--namespace` flag

### DIFF
--- a/helm_resource/helm-apply-helper.py
+++ b/helm_resource/helm-apply-helper.py
@@ -60,6 +60,7 @@ namespace = os.environ.get('NAMESPACE', '')
 if namespace:
   install_cmd.extend(['--namespace', namespace])
   get_cmd.extend(['--namespace', namespace])
+  kubectl_cmd.extend(['--namespace', namespace])
 
 install_cmd.extend([release_name, chart])
 get_cmd.extend([release_name])


### PR DESCRIPTION
If `namespace` is defined, the `--namespace` flag should be appended to the `kubectl_cmd` as well, otherwise the command will be unable to find the resources that are deployed to the non-default namespace.