### PR TITLE
Trivial version is not available anymore on later releases

### DIFF
--- a/kubebuilder/Tiltfile
+++ b/kubebuilder/Tiltfile
@@ -1,6 +1,6 @@
 load('ext://restart_process', 'docker_build_with_restart')
 
-def kubebuilder(DOMAIN, GROUP, VERSION, KIND, IMG='controller:latest', CONTROLLERGEN='rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases;', DISABLE_SECURITY_CONTEXT=True):
+def kubebuilder(DOMAIN, GROUP, VERSION, KIND, IMG='controller:latest', CONTROLLERGEN='rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases;', DISABLE_SECURITY_CONTEXT=True):
 
     DOCKERFILE = '''FROM golang:alpine
     WORKDIR /

--- a/kubebuilder/Tiltfile
+++ b/kubebuilder/Tiltfile
@@ -1,6 +1,6 @@
 load('ext://restart_process', 'docker_build_with_restart')
 
-def kubebuilder(DOMAIN, GROUP, VERSION, KIND, IMG='controller:latest', CONTROLLERGEN='crd:trivialVersions=true rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases;', DISABLE_SECURITY_CONTEXT=True):
+def kubebuilder(DOMAIN, GROUP, VERSION, KIND, IMG='controller:latest', CONTROLLERGEN='rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases;', DISABLE_SECURITY_CONTEXT=True):
 
     DOCKERFILE = '''FROM golang:alpine
     WORKDIR /


### PR DESCRIPTION
Was removed in version [0.7.0](https://github.com/kubernetes-sigs/controller-tools/commit/09f1952580d4e40a3aab8b1c4f6bfc8de3ae0b0b) latest is 0.16.2

