### PR TITLE
feat: Upgrade Prometheus to v0.13.0

### DIFF
--- a/coreos_prometheus/prometheus/node-exporter-daemonset.yaml
+++ b/coreos_prometheus/prometheus/node-exporter-daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.1.2
+    app.kubernetes.io/version: 1.8.2
   name: node-exporter
   namespace: monitoring
 spec:
@@ -16,23 +16,28 @@ spec:
       app.kubernetes.io/part-of: kube-prometheus
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: node-exporter
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: node-exporter
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 1.1.2
+        app.kubernetes.io/version: 1.8.2
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --web.listen-address=127.0.0.1:9100
         - --path.sysfs=/host/sys
         - --path.rootfs=/host/root
+        - --path.udev.data=/host/root/run/udev/data
         - --no-collector.wifi
         - --no-collector.hwmon
-        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
-        - --collector.netclass.ignored-devices=^(veth.*)$
-        - --collector.netdev.device-exclude=^(veth.*)$
-        image: quay.io/prometheus/node-exporter:v1.1.2
+        - --no-collector.btrfs
+        - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/k3s/containerd/.+|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+        - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$
+        - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$
+        image: quay.io/prometheus/node-exporter:v1.8.2
         name: node-exporter
         resources:
           limits:
@@ -41,16 +46,24 @@ spec:
           requests:
             cpu: 102m
             memory: 180Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - SYS_TIME
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /host/sys
+          mountPropagation: HostToContainer
           name: sys
-          readOnly: false
+          readOnly: true
         - mountPath: /host/root
           mountPropagation: HostToContainer
           name: root
           readOnly: true
       - args:
-        - --logtostderr
         - --secure-listen-address=[$(IP)]:9100
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --upstream=http://127.0.0.1:9100/
@@ -59,7 +72,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 9100
@@ -73,14 +86,23 @@ spec:
             cpu: 10m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
       hostNetwork: true
       hostPID: true
       nodeSelector:
         kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
       securityContext:
+        runAsGroup: 65534
         runAsNonRoot: true
         runAsUser: 65534
       serviceAccountName: node-exporter

--- a/coreos_prometheus/prometheus/prometheus-clusterRole.yaml
+++ b/coreos_prometheus/prometheus/prometheus-clusterRole.yaml
@@ -3,9 +3,10 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.26.0
+    app.kubernetes.io/version: 2.54.1
   name: prometheus-k8s
 rules:
 - apiGroups:
@@ -14,17 +15,8 @@ rules:
   - nodes/metrics
   verbs:
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  verbs:
-  - get
-  - list
-  - watch
 - nonResourceURLs:
   - /metrics
+  - /metrics/slis
   verbs:
   - get

--- a/coreos_prometheus/prometheus/prometheus-prometheus.yaml
+++ b/coreos_prometheus/prometheus/prometheus-prometheus.yaml
@@ -3,10 +3,10 @@ kind: Prometheus
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.26.0
-    prometheus: k8s
+    app.kubernetes.io/version: 2.54.1
   name: k8s
   namespace: monitoring
 spec:
@@ -16,16 +16,18 @@ spec:
       name: alertmanager-main
       namespace: monitoring
       port: web
+  enableFeatures: []
   externalLabels: {}
-  image: quay.io/prometheus/prometheus:v2.26.0
+  image: quay.io/prometheus/prometheus:v2.54.1
   nodeSelector:
     kubernetes.io/os: linux
   podMetadata:
     labels:
       app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 2.26.0
+      app.kubernetes.io/version: 2.54.1
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
   probeNamespaceSelector: {}
@@ -35,10 +37,9 @@ spec:
     requests:
       memory: 400Mi
   ruleNamespaceSelector: {}
-  ruleSelector:
-    matchLabels:
-      prometheus: k8s
-      role: alert-rules
+  ruleSelector: {}
+  scrapeConfigNamespaceSelector: {}
+  scrapeConfigSelector: {}
   securityContext:
     fsGroup: 2000
     runAsNonRoot: true
@@ -46,4 +47,4 @@ spec:
   serviceAccountName: prometheus-k8s
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
-  version: 2.26.0
+  version: 2.54.1


### PR DESCRIPTION
# Story

The version of Prometheus-Operator, v0.8.0, is a few years out of date. This is an attempt to update it to the latest available version, v0.13.0.