### PR TITLE
[helm_resource] Support specifying custom helm uninstall flags

### DIFF
--- a/helm_resource/README.md
+++ b/helm_resource/README.md
@@ -84,6 +84,8 @@ chart. Must be the same length as `image_deps`. Examples of accepted values:
 
 - Pass a values file as `flags=['--values=./path/to/values.yaml']`.
 
+`uninstall_flags`: Additional flags to pass to `helm uninstall`.
+
 `image_selector`: Image reference to determine containers eligible for Live Update.
   Only applicable if there are no images in `image_deps`.
 

--- a/helm_resource/Tiltfile
+++ b/helm_resource/Tiltfile
@@ -14,6 +14,7 @@ def helm_resource(
     image_deps=None,
     image_keys=None,
     flags=None,
+    uninstall_flags=None,
     image_selector='',
     container_selector='',
     live_update=None,
@@ -50,6 +51,7 @@ def helm_resource(
         by many charts.
 
     flags: Additional flags to pass to `helm install` (e.g., `['--set', 'key=value']`)
+    uninstall_flags: Additional flags to pass to `helm uninstall` (e.g., `['--no-hooks']`)
     image_selector: Image reference to determine containers eligible for Live Update.
       Only applicable if there are no images in `image_deps`.
     container_selector: Container reference to determine containers eligible for Live Update.
@@ -96,6 +98,9 @@ def helm_resource(
 
   if flags:
     apply_cmd.extend(flags)
+
+  if uninstall_flags:
+    delete_cmd.extend(uninstall_flags)
 
   dupe_deps = {}
   for i in range(len(image_deps)):

--- a/helm_resource/helm-delete-helper.py
+++ b/helm_resource/helm-delete-helper.py
@@ -9,16 +9,18 @@ import sys
 
 release_name = os.environ['RELEASE_NAME']
 namespace = os.environ.get('NAMESPACE', '')
-namespace_args = ('--namespace', namespace) if namespace else ()
+namespace_args = ['--namespace', namespace] if namespace else []
+
+flags = sys.argv[1:]
 
 # Check that release exists before uninstalling it
-status_cmd = ('helm', 'status') + namespace_args + (release_name,)
+status_cmd = ['helm', 'status', release_name] + namespace_args
 status_result = subprocess.call(
   status_cmd,
   stdout=subprocess.DEVNULL,
   stderr=subprocess.DEVNULL,
 )
 if status_result == 0:
-    delete_cmd = ('helm', 'uninstall') + namespace_args + (release_name,)
+    delete_cmd = ['helm', 'uninstall', release_name] + namespace_args + flags
     print('Running cmd: %s' % ' '.join(delete_cmd), file=sys.stderr)
     subprocess.call(delete_cmd)


### PR DESCRIPTION
This is a simple PR that adds an optional argument `uninstall_flags` to the `helm_resource` extension to support the ability to pass custom flags to the `helm uninstall` command. This is similar to the existing `flags` argument which passes custom flags to the `helm upgrade --install` command.