### PR TITLE
Fix helm_remote for OCI registries and add test

### DIFF
--- a/helm_remote/Tiltfile
+++ b/helm_remote/Tiltfile
@@ -143,9 +143,12 @@ def helm_remote_yaml(chart, repo_url='', repo_name='', release_name='', values=[
     if version != 'latest' and version != version.replace('/', '').replace('\\', ''):
         fail('Version cannot contain a forward slash')
 
+    is_oci = repo_url.startswith('oci://')
 
     # ======== Determine state of existing helm repo
-    if repo_url != '':
+    # helm does not support "repo {add, update}" for OCI based charts,
+    # see https://helm.sh/docs/topics/registries/#other-subcommands
+    if repo_url != '' and not is_oci:
         local_helm_repo = get_local_repo(repo_name, repo_url)
 
         if local_helm_repo == None:
@@ -164,6 +167,8 @@ def helm_remote_yaml(chart, repo_url='', repo_name='', release_name='', values=[
 
     # ======== Initialize
     # -------- targets
+    if is_oci:
+        repo_name = repo_url
     chart_target = _chart_target(chart, repo_name, version)
 
     cached_chart_exists = os.path.exists(chart_target)

--- a/helm_remote/test/Tiltfile
+++ b/helm_remote/test/Tiltfile
@@ -9,3 +9,10 @@ if not os.path.exists('./.helm/memcached'):
 docker_build('helm-remote-test-verify', '.')
 k8s_yaml('job.yaml')
 k8s_resource('helm-remote-test-verify', resource_deps=['memcached'])
+
+chart_version = '25.1.0'
+helm_remote('prometheus',
+            repo_url='oci://ghcr.io/prometheus-community/charts',
+            version=chart_version)
+if not os.path.exists('./.helm/oci/ghcr.io/prometheus-community/charts/%s/prometheus' % chart_version):
+  fail('prometheus failed to load in the right directory')


### PR DESCRIPTION
Using OCI charts currently fails on master with:
```
Error in local: command "helm repo add prometheus oci://ghcr.io/prometheus-community/charts" failed.
error: exit status 1
``` 