### PR TITLE
restart_wrapper: Be explicit about what signals are forwarded to entr

### DIFF
--- a/restart_process/tilt-restart-wrapper.go
+++ b/restart_process/tilt-restart-wrapper.go
@@ -60,7 +60,7 @@ func main() {
 
 	// Set up a signal forwarding handler
 	sigs := make(chan os.Signal, 10)
-	signal.Notify(sigs)
+	signal.Notify(sigs, syscall.SIGKILL, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		for sig := range sigs {
 			if *verboseSignals {


### PR DESCRIPTION
## Background

In #586 support for forwarding **all** signals sent to PID 1 on to `entr` was added. However, it doesn’t fully address the goal of #577, since the developer’s "true" entrypoint isn’t receiving those forwarded signals—only `entr` is. While this generally works for shutting down child processes, it can also forward unintended signals that break `entr`.

A concrete example is when the child process managed by `entr` becomes a zombie and gets re-parented to PID 1. The kernel then sends `SIGCHLD` to PID 1, which in turn forwards it to `entr`. These "spurious" `SIGCHLD` signals can cause `entr` to stop monitoring or restarting the process, breaking the `restart_wrapper` functionality.

### How to Reproduce

1. `kubectl exec` into a pod that uses `restart_wrapper`.
2. Run `kill -SIGCHLD <entr-pid>`.
3. After this, Tilt will detect file changes and run live update logic, but the process never actually restarts.

## Fix

To keep the spirit of #586 this PR changes the code so that **only** `SIGKILL`, `SIGINT`, and `SIGTERM` are forwarded. This prevents unintended signals (like `SIGCHLD`) from being passed to `entr`, avoiding the issue where `entr` stops managing its child processes after receiving unexpected signals.