### PR TITLE
Add build_dependencies flag to helm_resource

### DIFF
--- a/helm_resource/Tiltfile
+++ b/helm_resource/Tiltfile
@@ -24,6 +24,7 @@ def helm_resource(
     auto_init=True,
     pod_readiness='',
     update_dependencies=False,
+    build_dependencies=False,
     links=[]):
   """Installs a helm chart to a cluster.
 
@@ -68,6 +69,7 @@ def helm_resource(
       can start building). By default, Tilt will wait for pods to be ready if it
       thinks a resource has pods.
     update_dependencies: Runs `helm dependency update` before installing the chart.
+    build_dependencies: Runs `helm dependency build --skip-refresh` before installing the chart.
     links: One or more links to be associated with this resource in the UI.
   """
   if not release_name:
@@ -95,6 +97,9 @@ def helm_resource(
 
   if update_dependencies:
     env['TILT_HELM_RELEASE_DEPENDENCY_UPDATE'] = 'true'
+
+  if build_dependencies:
+    env['TILT_HELM_RELEASE_DEPENDENCY_BUILD'] = 'true'
 
   if flags:
     apply_cmd.extend(flags)

--- a/helm_resource/helm-apply-helper.py
+++ b/helm_resource/helm-apply-helper.py
@@ -72,6 +72,11 @@ if os.environ.get('TILT_HELM_RELEASE_DEPENDENCY_UPDATE', False) == 'true':
   print("Running cmd: %s" % dependency_update_cmd, file=sys.stderr)
   subprocess.check_call(dependency_update_cmd, stdout=sys.stderr)
 
+if os.environ.get('TILT_HELM_RELEASE_DEPENDENCY_BUILD', False) == 'true':
+  dependency_build_cmd = ['helm', 'dependency', 'build', chart, '--skip-refresh']
+  print("Running cmd: %s" % dependency_build_cmd, file=sys.stderr)
+  subprocess.check_call(dependency_build_cmd, stdout=sys.stderr)
+
 print("Running cmd: %s" % install_cmd, file=sys.stderr)
 subprocess.check_call(install_cmd, stdout=sys.stderr)
 


### PR DESCRIPTION
The `update_dependencies` flag will auto-bump versions in the `Chart.lock`. This isn't desirable in all situations. However, it's still useful to have the tilt managed `helm_resource` download (build) the dependencies in the first place.

Note: I'm not a tilt maintainer and unsure anything else that would need to be done here. I might suspect some test could be worth doing as well.