### PR TITLE
coreos_prometheus: bump to 0.15, remove operator dep

### DIFF
--- a/coreos_prometheus/Tiltfile
+++ b/coreos_prometheus/Tiltfile
@@ -52,7 +52,7 @@ def replace_target(src, target):
 def download_files():
     cachedir = _find_cache_dir()
 
-    kube_prometheus_version = '0.14.0'
+    kube_prometheus_version = '0.15.0'
     kube_prometheus_tarball = os.path.join(cachedir, 'coreos-kube-prometheus-%s.tar.gz' % kube_prometheus_version)
     kube_prometheus_tarball_quoted = shlex.quote(kube_prometheus_tarball)
 
@@ -113,7 +113,6 @@ def setup_monitoring():
     k8s_resource(
         new_name='prometheus-crds',
         objects = [('%s' % name(c)) for c in crds],
-        resource_deps=['prometheus-operator'],
     )
 
     resources = {


### PR DESCRIPTION
This bumps the kube-prometheus operator release to 0.15.0. This is because according to this [1] compatibility table, 0.14.0 is not supported by versions Kubernetes >= 1.32

This also removes the operator resource dependency for the CRDs. This inclusion means that the operator pod is started before the CRDs. This results in the pod not being able to read Prometheus or Alertmanager CRD resources, so the resulting pods are never created until the operator pod is restarted. Creating the CRDs before the operator pod fixes this problem.

[1] https://github.com/prometheus-operator/kube-prometheus?tab=readme-ov-file#compatibility