### PR TITLE
Add run_once extension for single execution in Tilt sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`pulumi`](/pulumi): Install Kubernetes resources with [Pulumi](https://www.pulumi.com/).
 - [`pypiserver`](/pypiserver): Run [pypiserver](https://pypi.org/project/pypiserver/) local container.
 - [`restart_process`](/restart_process): Wrap a `docker_build` or `custom_build` to restart the given entrypoint after a Live Update (replaces `restart_container()`)
+- [`run_once`](/run_once): Execute a function only once during a Tilt session.
 - [`secret`](/secret): Functions for creating secrets.
 - [`snyk`](/snyk): Use [Snyk](https://snyk.io) to test your containers, configuration files, and open source dependencies.
 - [`syncback`](/syncback): Sync files/directories from your container back to your local FS.

--- a/run_once/README.md
+++ b/run_once/README.md
@@ -1,0 +1,50 @@
+# Run Once
+
+Author: [Vittorio Adamo](https://github.com/adamovittorio)
+
+The Run Once extension provides a way to execute a function only once during a Tilt session. This extension is especially useful when working with multiple Tiltfiles that might declare the same resource. In such scenarios, without `run_once`, you would encounter errors due to resource redeclaration. For example, when multiple services require the same extension repository:
+
+```python
+load('ext://run_once', 'run_once')
+
+# Without run_once - will cause errors if included in multiple Tiltfiles
+v1alpha1.extension_repo(name='awesome-dev-platform', url='https://github.com/Organization/awesome-dev-platform', ref='v3.1.0')
+
+# With run_once - safely registers the repo only once
+for i in range(0, 5):
+  run_once(
+    name='awesome-dev-platform',
+    fn=lambda: v1alpha1.extension_repo(name='awesome-dev-platform', url='https://github.com/Organization/awesome-dev-platform', ref='v3.1.0')
+  )
+```
+
+This pattern ensures that common dependencies are only registered once during a Tilt session.
+
+## Configuration
+
+The extension uses a temporary directory to store state between Tilt updates. You can control where this directory is located by setting the `TILT_RUN_ONCE_TEMP_DIR` environment variable.
+
+```sh
+export TILT_RUN_ONCE_TEMP_DIR=/path/to/custom/dir
+tilt up
+```
+
+You can control the verbosity of the extension by setting the `TILT_RUN_ONCE_QUIET` environment variable.
+
+```sh
+export TILT_RUN_ONCE_QUIET=False
+tilt up
+```
+
+## How It Works
+
+1. When Tilt starts, the extension creates a temporary directory
+2. Resource names are recorded in a state file when they are first created
+3. Subsequent calls with the same resource name will be skipped
+4. The state is reset when Tilt is restarted
+
+## Notes
+
+- The state is maintained only during a single Tilt session
+- When Tilt is restarted, all run_once functions will execute again
+- Resources are tracked by name, so use unique names for different operations

--- a/run_once/Tiltfile
+++ b/run_once/Tiltfile
@@ -1,0 +1,71 @@
+quiet = os.getenv('TILT_RUN_ONCE_QUIET', 'True') == 'True'
+
+
+def _create_temp_dir():
+    from_env = os.getenv('TILT_RUN_ONCE_TEMP_DIR', '')
+
+    if from_env != '':
+        return from_env
+
+    tmpdir = str(local("mktemp -d", echo_off=quiet, quiet=quiet)).strip()
+    os.putenv('TILT_RUN_ONCE_TEMP_DIR', tmpdir)
+
+    return tmpdir
+
+def _get_state_file_path():
+  tilt_dir = _create_temp_dir()
+  return os.path.join(tilt_dir, 'run-once-state')
+
+def _add_resource_to_state_file(name):
+  """
+  Add a resource name to the state file if it doesn't exist
+  Args:
+    name: The resource name to add
+  Returns:
+    True if the resource was newly added, False if it already existed
+  """
+  read_cmd = 'cat {} 2>/dev/null || echo ""'.format(state_file)
+  state_content = str(local(read_cmd, quiet=quiet, echo_off=quiet)).strip()
+
+  # Parse existing resources
+  resources = [r for r in state_content.split('\n') if r.strip()]
+
+  # Check if resource already exists
+  if name in resources:
+    return False
+
+  resources.append(name)
+
+  content = '\n'.join(resources)
+  local('echo "{}" > {}'.format(content, state_file), quiet=quiet, echo_off=quiet)
+  return True
+
+def run_once(name, fn=None):
+  """
+  Execute a function once based on a persistent state file
+  Args:
+    name: The name of the resource to track
+    fn: A function to execute if the resource hasn't been created before
+  Returns:
+    The result of the function execution, or None if the resource already exists
+  """
+  if _add_resource_to_state_file(name):
+    print("Resource '{}' not found in state file, creating it...".format(name))
+    return fn()
+  else:
+    print("Resource '{}' already exists in state file, skipping creation".format(name))
+    return None
+
+
+state_file = _get_state_file_path()
+tilt_dir = os.path.dirname(state_file)
+
+if not quiet:
+  print("📄 Using state file: {}".format(state_file))
+
+
+# Always reset the state file at the beginning of a Tilt run
+local('mkdir -p {} && rm -f {}'.format(tilt_dir, state_file), quiet=quiet, echo_off=quiet)
+
+if not quiet:
+  print("🔄 Starting fresh Tilt session, run_once state reset")

--- a/run_once/test/Tiltfile
+++ b/run_once/test/Tiltfile
@@ -1,0 +1,8 @@
+load('../../helm_resource/Tiltfile', 'helm_repo')
+load('../Tiltfile', 'run_once')
+
+for i in range(0, 5):
+  run_once(
+    name='bitnami',
+    fn=lambda: helm_repo('bitnami', 'https://charts.bitnami.com/bitnami', labels=['charts'])
+  )


### PR DESCRIPTION
Introduce the `run_once` extension to allow functions to execute only once during a Tilt session, preventing resource redeclaration errors across multiple Tiltfiles. For example, when including a common dependency in a [Many Tiltfiles and Many Repos](https://docs.tilt.dev/multiple_repos.html) scenario.