### PR TITLE
fix kubectl_cmd namespace

### DIFF
--- a/helm_resource/helm-apply-helper.py
+++ b/helm_resource/helm-apply-helper.py
@@ -62,6 +62,7 @@ namespace = os.environ.get('NAMESPACE', '')
 if namespace:
   install_cmd.extend(['--namespace', namespace])
   get_cmd.extend(['--namespace', namespace])
+  kubectl_cmd.extend(['--namespace', namespace])
 
 install_cmd.extend([release_name, chart])
 get_cmd.extend([release_name])


### PR DESCRIPTION
Add namespace to kubectl_cmd

Before:
Running cmd: ['helm', 'get', 'manifest', '--namespace', 'local', ‘deploy-app']
Running cmd: ['kubectl', 'get', '-oyaml', '-f', '-']

After:
Running cmd: ['helm', 'get', 'manifest', '--namespace', 'local', ‘deploy-app']
Running cmd: ['kubectl', 'get', '--namespace', 'local', '-oyaml', '-f', '-']