### PR TITLE
Feat(dotenv) support multi-line values

### DIFF
--- a/dotenv/README.md
+++ b/dotenv/README.md
@@ -3,6 +3,7 @@
 Author: [ln](https://github.com/tachiniererin)
 
 dotenv reads `.env` or another specified file and loads the key value pairs into the environment.
+Supports multi-line strings, but only wrapped with double-quotes (`"`).
 
 ## Usage
 

--- a/dotenv/Tiltfile
+++ b/dotenv/Tiltfile
@@ -15,10 +15,12 @@ def dotenv(fn=".env", verbose=False, showValues=False):
     lines = str(f).splitlines()
 
     # Parse lines
-    for lineNumber in range(len(lines)):
+    lineNumber = 0
+    while lineNumber < len(lines):
 
         # Set line by line number
         line = lines[lineNumber]
+        lineNumber += 1
 
         # Skip comments
         if line.startswith("#"):
@@ -42,6 +44,20 @@ def dotenv(fn=".env", verbose=False, showValues=False):
 
         # Remove whitespace around the varible value
         varValue = v[1].strip()
+
+        # Multi-line quoted value support
+        if varValue.startswith('"') and not varValue.endswith('"'):
+            # Start of multi-line quoted value
+            value_lines = [v[1].lstrip()]
+            while lineNumber < len(lines):
+                next_line = lines[lineNumber]
+                lineNumber += 1
+                stripped = next_line.rstrip()
+                if stripped.endswith('"'):
+                    value_lines.append(stripped)
+                    break
+                value_lines.append(next_line)
+            varValue = "\n".join(value_lines)
 
         # if varValue starts and ends with quotes, remove them
         if varValue.startswith('"') and varValue.endswith('"'):

--- a/dotenv/test/.env
+++ b/dotenv/test/.env
@@ -10,4 +10,12 @@ THIRD=a = b
     ENV_VAR_WITH_QUOTES_1=" quotes 'and' spaces       "            
     ENV_VAR_WITH_QUOTES_2= ' quotes "and" spaces       '
     ENV_VAR_WITH_QUOTES_3 =' mixed 'quotes' "and" spaces       '            
-    ENV_VAR_WITH_QUOTES_4 = " value with non-matching quote characters and trailing spaces   '      
+
+# Multi-line quoted value test
+MULTILINE="This is a multi-line
+value that spans
+three lines."
+
+MULTILINE_WITH_SPACES="   This is a multi-line 
+   value that spans  
+   three lines with leading spaces.   "

--- a/dotenv/test/Tiltfile
+++ b/dotenv/test/Tiltfile
@@ -9,7 +9,8 @@ expected_variables = {
     "ENV_VAR_WITH_QUOTES_1": " quotes 'and' spaces       ",
     "ENV_VAR_WITH_QUOTES_2": ' quotes "and" spaces       ',
     "ENV_VAR_WITH_QUOTES_3": " mixed 'quotes' \"and\" spaces       ",
-    "ENV_VAR_WITH_QUOTES_4": "\" value with non-matching quote characters and trailing spaces   '"
+    "MULTILINE": "This is a multi-line\nvalue that spans\nthree lines.",
+    "MULTILINE_WITH_SPACES": "   This is a multi-line \n   value that spans  \n   three lines with leading spaces.   ",
 }
 
 unexpected_variables = [
@@ -17,8 +18,9 @@ unexpected_variables = [
 ]
 
 for key, value in expected_variables.items():
-    if os.getenv(key) != value:
-        fail("env variable '%s' with unexpected value. Expected '%s'" % (key, value))
+    received = os.getenv(key)
+    if received != value:
+        fail("env variable '%s' with unexpected value. Expected '%s', received '%s'" % (key, value, received))
 
 for key in unexpected_variables:
     if os.getenv(key) != None:


### PR DESCRIPTION
Closes #651 

Removes support for lines starting with a `"` and ending with a `'` — and removes the corresponding test-case.

Also updated the Readme for the extension: only double-quotes are supported for multi-line strings.