### PR TITLE
fix timeout failing to call fg

### DIFF
--- a/cancel/test/test.sh
+++ b/cancel/test/test.sh
@@ -12,11 +12,15 @@ timeout 30 tail -f tilt.log | grep -q "cmd.tilt.dev/sleep:update:cancel created"
 # Hit the cancel button. This should make tilt exit.
 ./trigger.sh
 
-# Move tilt ci to the foreground, and ignore errors
-timeout 15 fg
-
-grep -q "Running cmd: ./kill_cmd.sh sleep:update" tilt.log
-RESULT=$?
+# Wait for the asynchronous button event to run the cancellation command.
+RESULT=1
+for _ in {1..300}; do
+  if grep -q "Running cmd: ./kill_cmd.sh sleep:update" tilt.log; then
+    RESULT=0
+    break
+  fi
+  sleep 0.1
+done
 
 cat tilt.log
 rm tilt.log


### PR DESCRIPTION
`timeout 15 fg` fails because `timeout` tries to run `fg` as an external command and not the shell built-in (and results in command not found), since `cancel/test/test.sh` doesn't `set -e` this failure wasn't visible. In practice `grep` just runs after `./trigger.sh` making it prone to race conditions, adding a loop to retry grep up to 30s