### PR TITLE
fix request missing session token

### DIFF
--- a/cancel/test/trigger.sh
+++ b/cancel/test/trigger.sh
@@ -10,5 +10,9 @@ NEW_YAML=$(echo "$YAML" | sed "s/lastClickedAt.*/lastClickedAt: $TIME/g")
 # Follow this KEP:
 # https://github.com/kubernetes/enhancements/issues/2590
 # For now, we can handle it with curl.
-curl -X PUT -H "Content-Type: application/yaml" -d "$NEW_YAML" \
+COOKIE_JAR=$(mktemp)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+curl -fsS -c "$COOKIE_JAR" http://localhost:10350/ >/dev/null
+curl -fsS -b "$COOKIE_JAR" \
+  -X PUT -H "Content-Type: application/yaml" -d "$NEW_YAML" \
    http://localhost:10350/proxy/apis/tilt.dev/v1alpha1/uibuttons/sleep:update:cancel/status


### PR DESCRIPTION
since https://github.com/tilt-dev/tilt/pull/6776 requests need to include a session token, test was making a request without one and getting `missing session token` error because of it. Adding a request to get the token and including it in the original request.