### PR TITLE
pack: use the configured Docker host in lifecycle containers

### DIFF
--- a/pack/Tiltfile
+++ b/pack/Tiltfile
@@ -37,6 +37,9 @@ def pack(
     pack_build_cmd = " ".join([
       "pack build",
       caching_ref,
+      # Ensure lifecycle containers use the same daemon as the pack CLI when
+      # DOCKER_HOST points at a remote or proxied daemon.
+      "--docker-host inherit",
       "--path " + path,
       "--builder " + builder,
       "--pull-policy " + pull_policy,


### PR DESCRIPTION
  The Pack CLI respects `DOCKER_HOST`, but without  `--docker-host inherit` its lifecycle containers default to mounting `/var/run/docker.sock`.  `--docker-host inherit` ensures the lifecycle containers use the same daemon as the Pack CLI. When `DOCKER_HOST` is unset, Pack retains its standard socket behavior.